### PR TITLE
Hack to allow the vim-tmux-navigator plugin key bindings to interupt.

### DIFF
--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -197,7 +197,15 @@ class InputStream:
 
     def probe(self):
         try:
-            vim.eval("getchar(0)")
+            c = vim.eval("getchar(0)")
+            if c == "10":
+                vim.command('TmuxNavigateDown')
+            if c == "11":
+                vim.command('TmuxNavigateUp')
+            if c == "12":
+                vim.command('TmuxNavigateRight')
+            if c == "8":
+                vim.command('TmuxNavigateLeft')
         except: # vim.error
             raise UserInterrupt()
 


### PR DESCRIPTION
I'm sure there is a more elegant and flexible solution available, but thought it worth mentioning that I have just created this hack to work around #166 for myself.

This allows the `<c-h>`, `<c-j>`, `<c-k>` and `<c-l>` binding provided by the
vim-tmux-navigator plugin to be used to switch to a tmux pane while
vdebug waits for a connection to the debugger.

This is useful when debugging cli scripts and you need to change to a
differnt tmux pane so as to execute your script.