### PR TITLE
Fix for FilePath mapping between Unix and Win

### DIFF
--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -486,7 +486,7 @@ class StackGetResponseRenderer(ResponseRenderer):
         string = ""
         for s in stack:
             where = s.get('where') if s.get('where') else 'main'
-            file = vdebug.util.LocalFilePath(s.get('filename'))
+            file = vdebug.util.RemoteFilePath(s.get('filename'))
             line = "[%(num)s] %(where)s @ %(file)s:%(line)s" \
                     %{'num':s.get('level'),'where':where,\
                     'file':str(file),'line':s.get('lineno')}

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -91,6 +91,7 @@ class FilePath:
             self.is_win = True
             if filename[0] == "/":
                 filename = filename[1:]
+            filename = filename.replace('/', '\\')
 
         self.local = self._create_local(filename)
         self.remote = self._create_remote(filename)
@@ -101,17 +102,22 @@ class FilePath:
         Uses the "local_path" and "remote_path" options.
         """
         ret = f
-        if ret[2] == "/":
-            ret = ret.replace("/","\\")
-
+        
         if vdebug.opts.Options.isset('path_maps'):
             for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
                 if remote in ret:
                     vdebug.log.Log("Replacing remote path (%s) " % remote +\
                             "with local path (%s)" % local ,\
                             vdebug.log.Logger.DEBUG)
-                    ret = ret.replace(remote,local)
+                    ret = ret.replace(remote,local,1)
+
+                    # determine remote path separator and replace by local
+                    local_sep = self._findSeparator(local)
+                    remote_sep = self._findSeparator(remote)
+                    if local_sep and remote_sep and remote_sep != local_sep:
+                        ret = ret.replace(remote_sep, local_sep)
                     break
+
         return ret
 
     def _create_remote(self,f):
@@ -127,16 +133,15 @@ class FilePath:
                     vdebug.log.Log("Replacing local path (%s) " % local +\
                             "with remote path (%s)" % remote ,\
                             vdebug.log.Logger.DEBUG)
-                    ret = ret.replace(local,remote)
+                    ret = ret.replace(local,remote,1)
+                    # replace remaining local separators with URL '/' separators
+                    ret = ret.replace('\\', '/')
                     break
 
-        if ret[2] == "\\":
-            ret = ret.replace("\\","/")
-
-        if self.is_win:
-            return "file:///"+ret
-        else:
+        if ret.startswith('/'):
             return "file://"+ret
+        else:
+            return "file:///"+ret
 
     def as_local(self,quote = False):
         if quote:
@@ -146,6 +151,12 @@ class FilePath:
 
     def as_remote(self):
         return self.remote
+
+    def _findSeparator(self, path):
+        for sep in '\\/':
+            if sep in path:
+                return sep
+        return None
 
     def __eq__(self,other):
         if isinstance(other,FilePath):

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -135,3 +135,57 @@ class RemotePathTest(unittest.TestCase):
         filename = "C:/local2/path/to/file"
         file = FilePath(filename)
         self.assertEqual("C:\\local2\\path\\to\\file",file.as_local())
+
+class RemoteWinLocalUnixPathTest(unittest.TestCase):
+    def setUp(self):
+        vdebug.opts.Options.set({'path_maps':{'G:\\remote\\path':'/local/path', 'G:\\remote2\\path':'/local2/path'}})
+
+    def test_as_local(self):
+        filename = "G:\\remote\\path\\to\\file"
+        file = FilePath(filename)
+        self.assertEqual("/local/path/to/file",file.as_local())
+
+        filename = "file:///G:/remote2/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("/local2/path/to/file",file.as_local())
+
+    def test_as_local_does_nothing(self):
+        filename = "/the/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("/the/path/to/file",file.as_local())
+
+    def test_as_remote(self):
+        filename = "/local/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("file:///G:/remote/path/to/file",file.as_remote())
+
+        filename = "file:///local2/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("file:///G:/remote2/path/to/file",file.as_remote())
+
+class RemoteUnixLocalWinPathTest(unittest.TestCase):
+    def setUp(self):
+        vdebug.opts.Options.set({'path_maps':{'/remote/path':'G:\\local\\path', '/remote2/path':'G:\\local2\\path'}})
+
+    def test_as_local(self):
+        filename = "/remote/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("G:\\local\\path\\to\\file",file.as_local())
+
+        filename = "file:///remote2/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("G:\\local2\\path\\to\\file",file.as_local())
+
+    def test_as_local_does_nothing(self):
+        filename = "G:\\the\\path\\to\\file"
+        file = FilePath(filename)
+        self.assertEqual("G:\\the\\path\\to\\file",file.as_local())
+
+    def test_as_remote(self):
+        filename = "G:\\local\\path\\to\\file"
+        file = FilePath(filename)
+        self.assertEqual("file:///remote/path/to/file",file.as_remote())
+
+        filename = "file:///G:/local2/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("file:///remote2/path/to/file",file.as_remote())


### PR DESCRIPTION
Hi Jonathan,

I tried to debug an app running on Win32 with VIM/vdebug on Linux and didn't see any code in the source window. Despite my path mapping FilePath didn't get the remaining path separators right.

There is one patch for FilePath which should fix path separators in Unix<->Windows mixed scenarios that comes with some additional unit tests. The other one fixes the pathes in the Stack Window where s.get('filename') doesn't give the local but the RemoteFilePath.

With these small fixes I'm now happily debugging in cross OS scenarios thanks to your great VIM plugin.

Kind regards,
Bernd