### PR TITLE
Ordered path maps

### DIFF
--- a/doc/Vdebug.txt
+++ b/doc/Vdebug.txt
@@ -791,7 +791,7 @@ The default options look like this: >
     \    "on_close" : 'detach',
     \    "break_on_open" : 1,
     \    "ide_key" : '',
-    \    "path_maps" : {},
+    \    "path_maps" : [],
     \    "debug_window_level" : 0,
     \    "debug_file_level" : 0,
     \    "debug_file" : "",
@@ -852,7 +852,7 @@ g:vdebug_options["ide_key"] (default = empty)
     |VdebugIDEKey| for more information.
 
                                                        *VdebugOptions-path_maps*
-g:vdebug_options["path_maps"] (default = {})          
+g:vdebug_options["path_maps"] (default = [])          
     This is only used for debugging a script on a remote machine. This is used
     to map remote file paths to local file paths, as they are very likely to be
     different. This is a VimL dictionary of mappings between remote files (keys)
@@ -999,7 +999,7 @@ use your machine's IP and debugger port, and you can pick up the remote
 connection.
 
 There are a couple of hurdles to overcome in doing this:
-    
+
     1. File paths are unlikely to be the same on the local and remote machines
     2. You need to bind Vdebug to the right address, and make sure there's a
        network route between the two machines.
@@ -1012,19 +1012,26 @@ Firstly, file paths aren't a problem. You can use the options "remote_path" and
 eachother.
 
 Let's say we're debugging a file on a remote machine, and the path is
-/home/user/scripts/myscript.php. On my machine the same script is located in
+/var/www/scripts/myscript.php. On my machine the same script is located in
 /home/jon/php/myscript.php. I would have to set the remote and local path
 options as so: >
 
-    let g:vdebug_options['path_maps'] = {"/home/user/scripts": "/home/jon/php"}
+    let g:vdebug_options['path_maps'] = [{"/var/www/scripts": "/home/jon/php"}]
 <
 When the debugger engine sends any file paths, a straight swap of the paths is
-done, so all instances of "/home/user/scripts" are replaced with
+done, so all instances of "/var/www/scripts" are replaced with
 "/home/jon/php". The opposite is done when sending file paths in the other
 direction.
 
-It is possible to have multiple file path mappings by adding more items in the
-"path_maps" dictionary.
+It is possible to have multiple file path mappings by adding more dictionaries 
+to the "path_maps" list. Path maps are matched in order, allowing more
+specific mappings to be matched before being modified by general mappings: >
+
+    let g:vdebug_options['path_maps'] = [
+        \ {"/var/www/libs/some-lib": "/home/jon/libs/some-lib/dist"},
+        \ {"/var/www": "/home/jon/project/www"}
+        \ ]
+<
 
 ------------------------------------------------------------------------------
 9.2 Connecting the two machines                       *VdebugRemoteConnection*

--- a/plugin/python/vdebug/opts.py
+++ b/plugin/python/vdebug/opts.py
@@ -4,7 +4,7 @@ class Options:
 
     def __init__(self,options):
         self.options = options
-    
+
     @classmethod
     def set(cls,options):
         """Create an Options instance with the provided dictionary of
@@ -52,4 +52,3 @@ class Options:
 
 class OptionsError(Exception):
     pass
-

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -110,7 +110,9 @@ class FilePath:
             ret = ret.replace("/","\\")
 
         if vdebug.opts.Options.isset('path_maps'):
-            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+            for path_map in vdebug.opts.Options.get('path_maps', list):
+                remote = path_map.keys()[0]
+                local  = path_map.values()[0]
                 if remote in ret:
                     vdebug.log.Log("Replacing remote path (%s) " % remote +\
                             "with local path (%s)" % local ,\
@@ -127,7 +129,9 @@ class FilePath:
         ret = f
 
         if vdebug.opts.Options.isset('path_maps'):
-            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+            for path_map in vdebug.opts.Options.get('path_maps', list):
+                remote = path_map.keys()[0]
+                local  = path_map.values()[0]
                 if local in ret:
                     vdebug.log.Log("Replacing local path (%s) " % local +\
                             "with remote path (%s)" % remote ,\

--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -92,7 +92,7 @@ let g:vdebug_options_defaults = {
 \    "debug_window_level" : 0,
 \    "debug_file_level" : 0,
 \    "debug_file" : "",
-\    "path_maps" : {},
+\    "path_maps" : [],
 \    "watch_window_style" : 'expanded',
 \    "marker_default" : '⬦',
 \    "marker_closed_tree" : '▸',

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -9,7 +9,7 @@ from vdebug.util import FilePath,FilePathError
 class LocalFilePathTest(unittest.TestCase):
 
     def setUp(self):
-        vdebug.opts.Options.set({'path_maps':{}})
+        vdebug.opts.Options.set({'path_maps':[]})
 
     def test_as_local(self):
         filename = "/home/user/some/path"
@@ -80,7 +80,7 @@ class LocalFilePathTest(unittest.TestCase):
 
 class RemotePathTest(unittest.TestCase):
     def setUp(self):
-        vdebug.opts.Options.set({'path_maps':{'remote1':'local1', 'remote2':'local2'}})
+        vdebug.opts.Options.set({'path_maps':[{'remote1':'local1'}, {'remote2':'local2'}]})
 
     def test_as_local(self):
         filename = "/remote1/path/to/file"


### PR DESCRIPTION
Fixes #199 by changing the `path_maps` option from a dictionary, to an ordered list of dictionaries. This means paths will be matched in the order they are defined, allowing you to map specific paths before they are altered by more general ones:

```vim
let g:vdebug_options['path_maps'] = [
    \  {"/var/www/libs/some-lib": "/home/jon/libs/some-lib/dist"},
    \  {"/var/www": "/home/jon/project/www"}
    \ ]
```

This would introduce a breaking change, so it might be a good idea to include a deprication notice.