### PR TITLE
Fix remote debugging to listen to any connection instead of specific ip

### DIFF
--- a/plugin/python/vdebug/dbgp.py
+++ b/plugin/python/vdebug/dbgp.py
@@ -412,7 +412,7 @@ class Connection:
         try:
             serv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             serv.setblocking(0)
-            serv.bind((self.host, self.port))
+            serv.bind(('', self.port))
             serv.listen(5)
             (self.sock, self.address) = self.listen(serv, self.timeout)
             self.sock.settimeout(None)

--- a/plugin/python/vdebug/runner.py
+++ b/plugin/python/vdebug/runner.py
@@ -113,7 +113,7 @@ class Runner:
                 stack_res = self.update_stack()
                 stack = stack_res.get_stack()
 
-                self.cur_file = vdebug.util.RemoteFilePath(stack[0].get('filename'))
+                self.cur_file = vdebug.util.LocalFilePath(stack[0].get('filename'))
                 self.cur_lineno = stack[0].get('lineno')
 
                 vdebug.log.Log("Moving to current position in source window")

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -234,7 +234,7 @@ class SourceWindow(vdebug.ui.interface.Window):
 
     def set_line(self,lineno):
         self.focus()
-        vim.command("normal %sgg" % str(lineno))
+        vim.command("normal %sggzz" % str(lineno))
 
     def get_file(self):
         self.focus()

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -182,7 +182,19 @@ class LocalFilePath(FilePath):
 
         Uses the "local_path" and "remote_path" options.
         """
-        return f
+        ret = f
+        if ret[2] == "/":
+            ret = ret.replace("/","\\")
+
+        if vdebug.opts.Options.isset('path_maps'):
+            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+                if remote in ret:
+                    vdebug.log.Log("Replacing remote path (%s) " % remote +\
+                            "with local path (%s)" % local ,\
+                            vdebug.log.Logger.DEBUG)
+                    ret = ret.replace(remote,local)
+                    break
+        return ret
 
 class RemoteFilePath(FilePath):
     def _create_remote(self,f):
@@ -190,7 +202,24 @@ class RemoteFilePath(FilePath):
 
         Uses the "local_path" and "remote_path" options.
         """
-        return f
+        ret = f
+
+        if vdebug.opts.Options.isset('path_maps'):
+            for remote, local in vdebug.opts.Options.get('path_maps', dict).items():
+                if local in ret:
+                    vdebug.log.Log("Replacing local path (%s) " % local +\
+                            "with remote path (%s)" % remote ,\
+                            vdebug.log.Logger.DEBUG)
+                    ret = ret.replace(local,remote)
+                    break
+
+        if ret[2] == "\\":
+            ret = ret.replace("\\","/")
+
+        if self.is_win:
+            return "file:///"+ret
+        else:
+            return "file://"+ret
 
 class FilePathError(Exception):
     pass


### PR DESCRIPTION
This should fix any remote connection problems. The debugger now listens for any incoming connection whether it be localhost or remote. As long as a machine can access your computer over port 9000 you should be able to connect with this fix.