### PR TITLE
Debugger* buffers are not deleted on close

### DIFF
--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -354,7 +354,7 @@ class Window(vdebug.ui.interface.Window):
 
     def destroy(self):
         """ destroy window """
-        if not self.is_open or len(dir(self.buffer)) == 0:
+        if self.buffer == None or len(dir(self.buffer)) == 0:
             return
         self.is_open = False
         if int(vim.eval('buffer_exists("'+self.name+'")')) == 1:


### PR DESCRIPTION
When the debugging session is done and you close the debugger tab in
vim, the Debugger* buffers are just hidden, not deleted.

Change the check in the Window class back to 'self.buffer == None' from
'not self.is_open' to bail out of the destroy method.

fixes #225

Signed-off-by: BlackEagle <ike.devolder@gmail.com>