### PR TITLE
Quote filenames in breakpoint commands

### DIFF
--- a/plugin/python/vdebug/breakpoint.py
+++ b/plugin/python/vdebug/breakpoint.py
@@ -190,7 +190,7 @@ class LineBreakpoint(Breakpoint):
 
     def get_cmd(self):
         cmd = "-t " + self.type
-        cmd += " -f " + self.file.as_remote()
+        cmd += " -f " + '"' + self.file.as_remote() + '"'
         cmd += " -n " + str(self.line)
         cmd += " -s enabled"
         

--- a/tests/test_breakpoint_breakpoint.py
+++ b/tests/test_breakpoint_breakpoint.py
@@ -31,7 +31,7 @@ class LineBreakpointTest(unittest.TestCase):
         file = vdebug.util.FilePath("/path/to/file")
         line = 20
         bp = vdebug.breakpoint.LineBreakpoint(ui,file,line)
-        self.assertEqual(bp.get_cmd(),"-t line -f file://%s -n %i -s enabled" %(file, line))
+        self.assertEqual(bp.get_cmd(),"-t line -f \"file://%s\" -n %i -s enabled" %(file, line))
 
     def test_on_add_sets_ui_breakpoint(self):
         """ Test that the breakpoint is placed on the source window."""
@@ -63,7 +63,7 @@ class ConditionalBreakpointTest(unittest.TestCase):
         condition = "$x > 20"
         bp = vdebug.breakpoint.ConditionalBreakpoint(ui,file,line,condition)
         b64cond = base64.encodestring(condition)
-        exp_cmd = "-t conditional -f file://%s -n %i -s enabled -- %s" %(file, line, b64cond)
+        exp_cmd = "-t conditional -f \"file://%s\" -n %i -s enabled -- %s" %(file, line, b64cond)
         self.assertEqual(bp.get_cmd(), exp_cmd)
 
 class ExceptionBreakpointTest(unittest.TestCase):


### PR DESCRIPTION
Added quotes to the filenames passed with `-f` in breakpoint commands. This fixes a "parse error in command" error when setting breakpoints in scripts which have spaces in their file path. I initially thought the problem affected CLI scripts only, but now I think this is not actually related to CLI; it's just that web scripts are probably less likely to have spaces in their path.

I had used vdebug before to debug web php scripts and it worked perfectly. But then I attempted to debug a CLI script, and as soon as I ran it, it immediately exited and in vim there was an error message: "parse error in command". This happened only when using breakpoints. 

I enabled logging in xdebug and noticed the unquoted `file://...`  argument in the breakpoint command, and since my file had spaces in its path, it looked like the problem was there. After adding quotes, it started working fine.

This little bug probably went unnoticed because most scripts don't have spaces in their paths.

EDIT: it seems this should fix issue #105 (which is not Windows-specific, since I use Linux).
