### PR TITLE
Numeric keys break array inspection

### DIFF
--- a/plugin/python/vdebug/dbgp.py
+++ b/plugin/python/vdebug/dbgp.py
@@ -669,8 +669,12 @@ class EvalProperty(ContextProperty):
             if self.language == 'php' or \
                     self.language == 'perl':
                 if self.parent.type == 'array':
-                    self.display_name = self.parent.display_name + \
-                        "['%s']" % node.get('name')
+                    if node.get('name').isdigit():
+                        self.display_name = self.parent.display_name + \
+                            "[%s]" % node.get('name')
+                    else:
+                        self.display_name = self.parent.display_name + \
+                            "['%s']" % node.get('name')
                 else:
                     self.display_name = self.parent.display_name + \
                         "->"+node.get('name')

--- a/tests/test_dbgp_eval_property.py
+++ b/tests/test_dbgp_eval_property.py
@@ -1,0 +1,42 @@
+if __name__ == "__main__":
+    import sys
+    sys.path.append('../plugin/python/')
+import unittest2 as unittest
+import vdebug.dbgp
+import xml.etree.ElementTree as ET
+
+class EvalPropertyTest(unittest.TestCase):
+    def __get_eval_property(self,xml_string,code,lang):
+        xml = ET.fromstring(xml_string)
+        firstnode = xml[0]
+        return vdebug.dbgp.EvalProperty(firstnode,code,lang)
+
+    def test_numeric_keys(self):
+        prop = self.__get_eval_property(\
+            """<?xml version="1.0" encoding="iso-8859-1"?>
+<response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="eval" transaction_id="13">
+    <property 
+      address="140722906708544" type="array"
+      children="1" numchildren="2" page="0" pagesize="32">
+        <property
+          name="0" address="140022315302704"
+          type="array" children="1" numchildren="1"></property>
+        <property 
+          name="key" address="140022315307008"
+          type="array" children="1" numchildren="1"></property>
+    </property>
+</response>
+""", '$testarr', 'php')
+
+        self.assertEqual(prop.display_name,'$testarr')
+        self.assertEqual(prop.value,'')
+        self.assertEqual(prop.type,'array')
+        self.assertEqual(prop.depth,0)
+        self.assertTrue(prop.has_children)
+        self.assertEqual(prop.child_count(),2)
+
+        self.assertEqual(prop.children[0].type,'array')
+        self.assertEqual(prop.children[0].display_name,'$testarr[0]')
+
+        self.assertEqual(prop.children[1].type,'array')
+        self.assertEqual(prop.children[1].display_name,"$testarr['key']")


### PR DESCRIPTION
I'd noticed sporadically not being able to open sub-arrays in the watch window, but finally was able to track it down.  Turns out what caused trouble was arrays under *numeric keys* in *eval'd* (i.e. <F12>) variables.  I made [a quick screencast](https://gfycat.com/FickleDearIndianskimmer) to demo, since I had to do a demo to get the XML anyway, and already had OBS installed from previous adventures.  And here's [a logfile](https://github.com/joonty/vdebug/files/301605/vdebug_log.txt).

Details: this happens because when a variable is eval'd, we don't have the `fullname` key in the Xdebug response, so we have to reconstruct the `display_name`, which, for array keys, the current code does by wrapping the name in `['%s']`.  Then when we ask Xdebug for `$var['0']`, it croaks - and, [per a WONTFIX](https://bugs.xdebug.org/view.php?id=732) in their bug tracker, plan on continuing to do so, preferring that clients use a canonical `$var[0]` for numeric keys.

So, that's what this fix does - it includes a test to ensure `display_name` comes out correctly when provided an XML response from an eval'd variable with numeric and string keys, in a format that Xdebug will recognize.