### PR TITLE
Correct loading if in subfolder python

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -29,7 +29,7 @@ silent doautocmd User VdebugPre
 " /usr/local/share/vim/vim71/plugin/ if you're running Vim 7.1) or from the
 " home vim directory (usually ~/.vim/plugin/).
 if filereadable($VIMRUNTIME."/plugin/python/start_vdebug.py")
-  pyfile $VIMRUNTIME/plugin/start_vdebug.py
+  pyfile $VIMRUNTIME/plugin/python/start_vdebug.py
 elseif filereadable($HOME."/.vim/plugin/python/start_vdebug.py")
   pyfile $HOME/.vim/plugin/python/start_vdebug.py
 else


### PR DESCRIPTION
Checking if the file exists in the python subfolder of plugin is followed by loading without the subfolder.  Correct this.
