### PR TITLE
Fixed a crash when digits keys have been remapped

### DIFF
--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -244,7 +244,7 @@ class SourceWindow(vdebug.ui.interface.Window):
 
     def set_line(self,lineno):
         self.focus()
-        vim.command("normal %sgg" % str(lineno))
+        vim.command(":%s" % str(lineno))
 
     def get_file(self):
         self.focus()


### PR DESCRIPTION
To be able to efficiently use vim with an AZERTY keyboard (where by default digits can only be used in caps mode or with shift), I remapped some keys in my vimrc, like that:

```
noremap & 1
noremap é 2
noremap " 3
noremap ' 4
noremap ( 5
noremap - 6
noremap è 7
noremap _ 8
noremap ç 9
noremap à 0

noremap 1 &
noremap 2 é
noremap 3 "
noremap 4 '
noremap 5 (
noremap 6 -
noremap 7 è
noremap 8 _
noremap 9 ç
noremap 0 à
```

However, this causes a crash in vdebug since it tries to move to a line using the `XXgg` command.
I fixed this crash by using the alternative syntax (`:XX`) to move to the required line.
