### PR TITLE
:set nonumber for vdebug windows

### DIFF
--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -346,7 +346,7 @@ class Window(vdebug.ui.interface.Window):
         """ create window """
         vim.command('silent ' + self.open_cmd + ' ' + self.name)
         vim.command("setlocal buftype=nofile modifiable "+ \
-                "winfixheight winfixwidth")
+                "winfixheight winfixwidth nonumber")
         self.buffer = vim.current.buffer
         self.is_open = True
         self.creation_count += 1


### PR DESCRIPTION
Problem: the Vdebug windows have line numbers, but those numbers are meaningless, and they just take up valuable screen space.

Solution: `:setlocal nonumber`

I haven't tested this change. I've edited it directly into the GitHub web interface.

Future work: look what other settings NERDTree sets, maybe some of them are useful here.
https://github.com/scrooloose/nerdtree/blob/eee431dbd44111c858c6d33ffd366cae1f17f8b3/lib/nerdtree/creator.vim#L284