### PR TITLE
Fixes #127 - too short lines are ignored, which causes issues with va…

### DIFF
--- a/plugin/python/vdebug/event.py
+++ b/plugin/python/vdebug/event.py
@@ -181,6 +181,13 @@ class WatchWindowHideEvent(Event):
         end_lineno = buf_len - 1
         for i in range(lineno,end_lineno):
             buf_line = vim.current.buffer[i]
+
+            # If the value of the variable contains a new line and the new line
+            # is shorter than the variables tree level, skip it, to avoid an
+            # IndexError
+            if pointer_index >= len(buf_line):
+                continue
+
             char = buf_line[pointer_index]
             if char != " ":
                 end_lineno = i - 1

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -587,10 +587,13 @@ class ContextGetResponseRenderer(ResponseRenderer):
             return ""
 
     def __render_property(self,p,next_p,last = False,indent = 0):
+        indent_str = "".rjust((p.depth * 2)+indent)
         line = "%(indent)s %(marker)s %(name)s = (%(type)s)%(value)s" \
-                %{'indent':"".rjust((p.depth * 2)+indent),\
+                %{'indent':indent_str,\
                 'marker':self.__get_marker(p),'name':p.display_name.encode('latin1'),\
-                'type':p.type_and_size(),'value': " " + p.value}
+                'type':p.type_and_size(),'value': " " + p.value.replace(
+                        "\n",
+                        "\\n'\n%(indent)s'"%{'indent':indent_str})}
         line = line.rstrip() + "\n"
 
         if vdebug.opts.Options.get('watch_window_style') == 'expanded':


### PR DESCRIPTION
…riables having a multiline value, and where the length of any of the lines is shorter that the level of the variable in the watch tree.