### PR TITLE
Remove dependency on unittest2

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,16 +5,16 @@
 ## Introduction
 
 Vdebug is a new, fast, powerful debugger client for Vim. It's multi-language,
-and has been tested with PHP, Python, Ruby, Perl, Tcl and NodeJS. It interfaces with 
-**any** debugger that faithfully uses the DBGP protocol, such as Xdebug for PHP.  
-There are step-by-step instructions for setting up debugging with all of the aforementioned 
-languages in the Vim help file that comes with Vdebug. 
+and has been tested with PHP, Python, Ruby, Perl, Tcl and NodeJS. It interfaces with
+**any** debugger that faithfully uses the DBGP protocol, such as Xdebug for PHP.
+There are step-by-step instructions for setting up debugging with all of the aforementioned
+languages in the Vim help file that comes with Vdebug.
 
-It builds on the experience gained through the legacy of the Xdebug Vim script 
+It builds on the experience gained through the legacy of the Xdebug Vim script
 originally created by Seung Woo Shin and extended by so many others, but it's a
 total rebuild to allow for a nicer interface and support of new features.
 
-It's written in Python, and has an object-oriented interface that is easy to extend 
+It's written in Python, and has an object-oriented interface that is easy to extend
 and can even be used from the command-line. It even has unit tests covering
 some of the more critical parts of the code.
 
@@ -172,10 +172,9 @@ I gladly accept contributions to the code. Just fork the repository, make your c
 
 ## Tests
 
- * The tests use `unittest2` and `mock`, so make sure they're installed
+ * The tests use `unittest` (should be part of the stdlib) and `mock`, so make sure they're installed
 
 ```
-pip install unittest2
 pip install mock
 ```
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -139,7 +139,7 @@ set relativenumber
 EOF
 
 chown vagrant:vagrant /home/vagrant/.vimrc
-pip install unittest2 mock
+pip install mock
 
 # Do things as the vagrant user
 sudo -u vagrant bash << EOF

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
-unittest2
 mock

--- a/tests/test_breakpoint_breakpoint.py
+++ b/tests/test_breakpoint_breakpoint.py
@@ -1,7 +1,7 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 import vdebug.breakpoint
 import vdebug.util
 import base64

--- a/tests/test_dbgp_api.py
+++ b/tests/test_dbgp_api.py
@@ -1,11 +1,11 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 import vdebug.dbgp
 from mock import MagicMock, patch
 
-class ApiTest(unittest.TestCase):      
+class ApiTest(unittest.TestCase):
     """Test the Api class in the vdebug.dbgp module."""
 
     init_msg = """<?xml version="1.0"

--- a/tests/test_dbgp_connection.py
+++ b/tests/test_dbgp_connection.py
@@ -1,7 +1,7 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 import vdebug.dbgp
 
 class SocketMockError():
@@ -41,7 +41,7 @@ class SocketMock():
         pass
 
 
-class ConnectionTest(unittest.TestCase):      
+class ConnectionTest(unittest.TestCase):
 
     def setUp(self):
         self.conn = vdebug.dbgp.Connection('', 0)
@@ -81,8 +81,8 @@ class ConnectionTest(unittest.TestCase):
         self.conn.sock.add_response('')
         self.assertRaises(EOFError,self.conn.recv_msg)
 
-    """ 
-    Test that the send_msg command calls send on the socket, 
+    """
+    Test that the send_msg command calls send on the socket,
     and adds a null byte to the string.
     """
     def test_send(self):

--- a/tests/test_dbgp_context_property.py
+++ b/tests/test_dbgp_context_property.py
@@ -1,7 +1,7 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 import vdebug.dbgp
 import xml.etree.ElementTree as ET
 

--- a/tests/test_dbgp_eval_property.py
+++ b/tests/test_dbgp_eval_property.py
@@ -1,7 +1,7 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 import vdebug.dbgp
 import xml.etree.ElementTree as ET
 
@@ -15,13 +15,13 @@ class EvalPropertyTest(unittest.TestCase):
         prop = self.__get_eval_property(\
             """<?xml version="1.0" encoding="iso-8859-1"?>
 <response xmlns="urn:debugger_protocol_v1" xmlns:xdebug="http://xdebug.org/dbgp/xdebug" command="eval" transaction_id="13">
-    <property 
+    <property
       address="140722906708544" type="array"
       children="1" numchildren="2" page="0" pagesize="32">
         <property
           name="0" address="140022315302704"
           type="array" children="1" numchildren="1"></property>
-        <property 
+        <property
           name="key" address="140022315307008"
           type="array" children="1" numchildren="1"></property>
     </property>

--- a/tests/test_dbgp_response.py
+++ b/tests/test_dbgp_response.py
@@ -1,12 +1,12 @@
 import sys
 if __name__ == "__main__":
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 import vdebug.dbgp
 import xml
 from mock import Mock
 
-class ResponseTest(unittest.TestCase): 
+class ResponseTest(unittest.TestCase):
     """Test the response class in the vdebug.dbgp module."""
 
     def test_get_cmd(self):
@@ -35,15 +35,15 @@ class ResponseTest(unittest.TestCase):
         element"""
         response = """<?xml version="1.0" encoding="iso-8859-1"?>
             <response xmlns="urn:debugger_protocol_v1"
-            xmlns:xdebug="http://xdebug.org/dbgp/xdebug" 
-            command="status" transaction_id="1" status="starting" 
+            xmlns:xdebug="http://xdebug.org/dbgp/xdebug"
+            command="status" transaction_id="1" status="starting"
             reason="ok"></response>"""
         res = vdebug.dbgp.Response(response,"","",Mock())
         self.assertIsInstance(res.as_xml(),xml.etree.ElementTree.Element)
 
     def test_error_tag_raises_exception(self):
         response = """<?xml version="1.0" encoding="iso-8859-1"?>
-            <response xmlns="urn:debugger_protocol_v1" 
+            <response xmlns="urn:debugger_protocol_v1"
             xmlns:xdebug="http://xdebug.org/dbgp/xdebug"
             command="stack_get" transaction_id="4"><error
             code="5"><message><![CDATA[command is not available]]>
@@ -51,42 +51,42 @@ class ResponseTest(unittest.TestCase):
         re = "command is not available"
         self.assertRaisesRegexp(vdebug.dbgp.DBGPError,re,vdebug.dbgp.Response,response,"","",Mock())
 
-class StatusResponseTest(unittest.TestCase): 
+class StatusResponseTest(unittest.TestCase):
     """Test the behaviour of the StatusResponse class."""
     def test_string_is_status_text(self):
         response = """<?xml version="1.0" encoding="iso-8859-1"?>
             <response xmlns="urn:debugger_protocol_v1"
-            xmlns:xdebug="http://xdebug.org/dbgp/xdebug" 
-            command="status" transaction_id="1" status="starting" 
+            xmlns:xdebug="http://xdebug.org/dbgp/xdebug"
+            command="status" transaction_id="1" status="starting"
             reason="ok"></response>"""
         res = vdebug.dbgp.StatusResponse(response,"","",Mock())
         assert str(res) == "starting"
 
-class FeatureResponseTest(unittest.TestCase): 
+class FeatureResponseTest(unittest.TestCase):
     """Test the behaviour of the FeatureResponse class."""
     def test_feature_is_supported(self):
         response = """<?xml version="1.0" encoding="iso-8859-1"?>
-            <response xmlns="urn:debugger_protocol_v1" 
-            xmlns:xdebug="http://xdebug.org/dbgp/xdebug" 
-            command="feature_get" transaction_id="2" 
+            <response xmlns="urn:debugger_protocol_v1"
+            xmlns:xdebug="http://xdebug.org/dbgp/xdebug"
+            command="feature_get" transaction_id="2"
             feature_name="max_depth" supported="1"><![CDATA[1]]></response>"""
         res = vdebug.dbgp.FeatureGetResponse(response,"","",Mock())
         assert res.is_supported() == 1
 
     def test_feature_is_not_supported(self):
         response = """<?xml version="1.0" encoding="iso-8859-1"?>
-            <response xmlns="urn:debugger_protocol_v1" 
-            xmlns:xdebug="http://xdebug.org/dbgp/xdebug" 
-            command="feature_get" transaction_id="2" 
+            <response xmlns="urn:debugger_protocol_v1"
+            xmlns:xdebug="http://xdebug.org/dbgp/xdebug"
+            command="feature_get" transaction_id="2"
             feature_name="max_depth" supported="0"><![CDATA[0]]></response>"""
         res = vdebug.dbgp.FeatureGetResponse(response,"","",Mock())
         assert res.is_supported() == 0
 
-class StackGetTest(unittest.TestCase): 
+class StackGetTest(unittest.TestCase):
     """Test the behaviour of the StackGetResponse class."""
     def test_string_is_status_text(self):
         response = """<?xml version="1.0" encoding="iso-8859-1"?>
-            <response xmlns="urn:debugger_protocol_v1" 
+            <response xmlns="urn:debugger_protocol_v1"
             xmlns:xdebug="http://xdebug.org/dbgp/xdebug"
             command="stack_get" transaction_id="8">
                 <stack where="{main}" level="0" type="file"

--- a/tests/test_opts_options.py
+++ b/tests/test_opts_options.py
@@ -1,7 +1,7 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 from vdebug.opts import Options,OptionsError
 
 class OptionsTest(unittest.TestCase):

--- a/tests/test_util_environment.py
+++ b/tests/test_util_environment.py
@@ -1,7 +1,7 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 """ Mock vim import """
 import vdebug.log
 import vim

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -1,7 +1,7 @@
 if __name__ == "__main__":
     import sys
     sys.path.append('../plugin/python/')
-import unittest2 as unittest
+import unittest
 import vdebug.opts
 from vdebug.util import FilePath,FilePathError
 

--- a/vdebugtests.py
+++ b/vdebugtests.py
@@ -1,4 +1,4 @@
-import unittest2 as unittest
+import unittest
 import sys
 
 sys.path.append('tests')


### PR DESCRIPTION
The package description on pypi says that it is about backporting py2.7 improvements of the unittest module to 2.4+. But 2.7 should be pretty ubiquitous today and Vdebug also tries to move to py3.