### PR TITLE
Fix tests for py2 and py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ language: python
 python:
 - '2.6'
 - '2.7'
+- '3.6'
 rvm: 1.9.3
 before_install:
 - sudo apt-get update && sudo apt-get install vim-gtk php5-cli php5-xdebug

--- a/plugin/python/vdebug/breakpoint.py
+++ b/plugin/python/vdebug/breakpoint.py
@@ -12,13 +12,13 @@ class Store:
         num_bps = len(self.breakpoints)
         if num_bps > 0:
             vdebug.log.Log("Registering %i breakpoints with the debugger" % num_bps)
-        for id, bp in self.breakpoints.iteritems():
+        for id, bp in self.breakpoints.items():
             res = self.api.breakpoint_set(bp.get_cmd())
             bp.set_debugger_id(res.get_id())
 
     # Update line-based breakpoints with a dict of IDs and lines
     def update_lines(self,lines):
-        for id, line in lines.iteritems():
+        for id, line in lines.items():
             try:
                 self.breakpoints[id].set_line(line)
                 vdebug.log.Log("Updated line number of breakpoint %s to %s"\
@@ -61,7 +61,7 @@ class Store:
 
     def find_breakpoint(self,file,line):
         found = None
-        for id, bp in self.breakpoints.iteritems():
+        for id, bp in self.breakpoints.items():
             if bp.type == "line":
                 if bp.get_file() == file and\
                         bp.get_line() == line:
@@ -89,7 +89,7 @@ class Breakpoint:
 
     def __init__(self,ui):
         self.id = Breakpoint.id
-        Breakpoint.id += 1 
+        Breakpoint.id += 1
         self.ui = ui
 
     def get_id(self):
@@ -193,7 +193,7 @@ class LineBreakpoint(Breakpoint):
         cmd += " -f " + '"' + self.file.as_remote() + '"'
         cmd += " -n " + str(self.line)
         cmd += " -s enabled"
-        
+
         return cmd
 
 class TemporaryLineBreakpoint(LineBreakpoint):

--- a/plugin/python/vdebug/breakpoint.py
+++ b/plugin/python/vdebug/breakpoint.py
@@ -216,7 +216,7 @@ class ConditionalBreakpoint(LineBreakpoint):
 
     def get_cmd(self):
         cmd = LineBreakpoint.get_cmd(self)
-        cmd += " -- " + base64.encodestring(self.condition)
+        cmd += " -- " + base64.encodestring(self.condition.encode("UTF-8")).decode("UTF-8")
         return cmd
 
 class WatchBreakpoint(Breakpoint):

--- a/plugin/python/vdebug/connection.py
+++ b/plugin/python/vdebug/connection.py
@@ -1,10 +1,15 @@
 from __future__ import print_function
-import socket
-import time
-import sys
+
 import os
-import Queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
+import socket
+import sys
 import threading
+import time
+
 import vdebug.log
 
 class ConnectionHandler:
@@ -188,7 +193,7 @@ class BackgroundSocketCreator(threading.Thread):
         try:
             #self.log("Checking for exit")
             self.__check_exit(self.__message_q.get_nowait())
-        except Queue.Empty:
+        except queue.Empty:
             pass
 
     def __check_exit(self, message):
@@ -197,8 +202,8 @@ class BackgroundSocketCreator(threading.Thread):
 
 class SocketServer:
     def __init__(self):
-        self.__message_q = Queue.Queue(0)
-        self.__socket_q = Queue.Queue(1)
+        self.__message_q = queue.Queue(0)
+        self.__socket_q = queue.Queue(1)
         self.__thread = None
 
     def __del__(self):

--- a/plugin/python/vdebug/dbgp.py
+++ b/plugin/python/vdebug/dbgp.py
@@ -557,7 +557,7 @@ class ContextProperty:
                 if node.text is None:
                     self.value = ""
                 else:
-                    self.value = base64.decodestring(node.text)
+                    self.value = base64.decodestring(node.text.encode("UTF-8")).decode("UTF-8")
             elif not self.is_uninitialized() \
                     and not self.has_children:
                 self.value = node.text
@@ -590,7 +590,7 @@ class ContextProperty:
         n = node.find('%s%s' %(self.ns, name))
         if n is not None and n.text is not None:
             if n.get('encoding') == 'base64':
-                val = base64.decodestring(n.text)
+                val = base64.decodestring(n.text.encode("UTF-8")).decode("UTF-8")
             else:
                 val = n.text
         else:

--- a/plugin/python/vdebug/log.py
+++ b/plugin/python/vdebug/log.py
@@ -103,7 +103,7 @@ class Log:
 
     @classmethod
     def log(cls, string, level = Logger.INFO):
-        for k, l in cls.loggers.iteritems():
+        for k, l in cls.loggers.items():
             l.log(string,level)
 
     @classmethod
@@ -124,7 +124,7 @@ class Log:
 
     @classmethod
     def shutdown(cls):
-        for k, l in cls.loggers.iteritems():
+        for k, l in cls.loggers.items():
             l.shutdown()
         cls.loggers = {}
 

--- a/plugin/python/vdebug/session.py
+++ b/plugin/python/vdebug/session.py
@@ -227,7 +227,7 @@ class Session:
         value. This doesn't break the loop, so multiple features can be set
         even in the case of an error."""
         features = vim.eval('g:vdebug_features')
-        for name, value in features.iteritems():
+        for name, value in features.items():
             try:
                 self.__api.feature_set(name, value)
             except vdebug.dbgp.DBGPError as e:

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -44,7 +44,7 @@ class WindowManager:
         self.window(name).toggle(self._command(name))
 
     def close(self):
-        for name, win in self._windows.iteritems():
+        for name, win in self._windows.items():
             win.destroy()
 
     def watch(self):
@@ -749,7 +749,7 @@ class ContextGetResponseRenderer(ResponseRenderer):
     def __create_tabs(self):
         res = []
         if self.contexts:
-            for id,name in self.contexts.iteritems():
+            for id,name in self.contexts.items():
                 if self.current_context == id:
                     name = "*"+name
                 res.append("[ %s ]" % name)

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -210,7 +210,7 @@ class FilePath:
         ret = f
 
         if vdebug.opts.Options.isset('path_maps'):
-            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).iteritems(), key=lambda l: len(l[0]), reverse=True)
+            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).items(), key=lambda l: len(l[0]), reverse=True)
             for remote, local in sorted_path_maps:
                 if remote in ret:
                     vdebug.log.Log("Replacing remote path (%s) " % remote +\
@@ -235,7 +235,7 @@ class FilePath:
         ret = f
 
         if vdebug.opts.Options.isset('path_maps'):
-            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).iteritems(), key=lambda l: len(l[0]), reverse=True)
+            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).items(), key=lambda l: len(l[0]), reverse=True)
             for remote, local in sorted_path_maps:
                 if local in ret:
                     vdebug.log.Log("Replacing local path (%s) " % local +\

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -1,16 +1,22 @@
 from __future__ import print_function
+
+import os
+import re
+import socket
+import sys
+import time
+import traceback
+try:
+    import urllib.parse as urllib
+except ImportError:
+    import urllib
+
+import vim
+
 import vdebug.opts
 import vdebug.log
 import vdebug.session
 import vdebug.breakpoint
-import vim
-import re
-import os
-import sys
-import traceback
-import socket
-import urllib
-import time
 
 class ExceptionHandler:
     def __init__(self, session_handler):

--- a/tests/test_breakpoint_breakpoint.py
+++ b/tests/test_breakpoint_breakpoint.py
@@ -62,7 +62,7 @@ class ConditionalBreakpointTest(unittest.TestCase):
         line = 20
         condition = "$x > 20"
         bp = vdebug.breakpoint.ConditionalBreakpoint(ui,file,line,condition)
-        b64cond = base64.encodestring(condition)
+        b64cond = base64.encodestring(condition.encode("UTF-8")).decode("UTF-8")
         exp_cmd = "-t conditional -f \"file://%s\" -n %i -s enabled -- %s" %(file, line, b64cond)
         self.assertEqual(bp.get_cmd(), exp_cmd)
 


### PR DESCRIPTION
This updates the python code and tests to make the tests pass with python2 and python3.  I don't know if the whole thing can be used with python3 yet.  The aim is to enable the tests also for py3 on travis.