### PR TITLE
Sort imports and prepare them for py3

### DIFF
--- a/plugin/python/start_vdebug.py
+++ b/plugin/python/start_vdebug.py
@@ -1,6 +1,6 @@
-import sys
-import os
 import inspect
+import os
+import sys
 
 directory = os.path.dirname(inspect.getfile(inspect.currentframe()))
 sys.path.append(directory)

--- a/plugin/python/vdebug/breakpoint.py
+++ b/plugin/python/vdebug/breakpoint.py
@@ -1,7 +1,7 @@
 import base64
 
+from . import error
 from . import log
-from . import util
 
 class Store:
 
@@ -47,7 +47,7 @@ class Store:
     def remove_breakpoint_by_id(self,id):
         id = str(id)
         if id not in self.breakpoints:
-            raise BreakpointError("No breakpoint matching ID %s" % id)
+            raise error.BreakpointError("No breakpoint matching ID %s" % id)
         log.Log("Removing breakpoint id %s" % id)
         if self.api is not None:
             dbg_id = self.breakpoints[id].get_debugger_id()
@@ -75,9 +75,6 @@ class Store:
         keys = self.breakpoints.keys()
         keys.sort()
         return map(self.breakpoints.get,keys)
-
-class BreakpointError(Exception):
-    pass
 
 class Breakpoint:
     """ Abstract factory for creating a breakpoint object.
@@ -121,10 +118,10 @@ class Breakpoint:
                 file = ui.get_current_file()
                 line = ui.get_current_line()
                 if len(line.strip()) == 0:
-                    raise BreakpointError('Cannot set a breakpoint ' +\
+                    raise error.BreakpointError('Cannot set a breakpoint ' +\
                                             'on an empty line')
-            except util.FilePathError:
-                raise BreakpointError('No file, cannot set breakpoint')
+            except error.FilePathError:
+                raise error.BreakpointError('No file, cannot set breakpoint')
             return LineBreakpoint(ui,file,row)
         else:
             arg_parts = args.split(' ')
@@ -134,36 +131,36 @@ class Breakpoint:
                 row = ui.get_current_row()
                 file = ui.get_current_file()
                 if len(arg_parts) == 0:
-                    raise BreakpointError("Conditional breakpoints " +\
+                    raise error.BreakpointError("Conditional breakpoints " +\
                             "require a condition to be specified")
                 cond = " ".join(arg_parts)
                 return ConditionalBreakpoint(ui,file,row,cond)
             elif type == 'watch':
                 if len(arg_parts) == 0:
-                    raise BreakpointError("Watch breakpoints " +\
+                    raise error.BreakpointError("Watch breakpoints " +\
                             "require a condition to be specified")
                 expr = " ".join(arg_parts)
                 log.Log("Expression: %s"%expr)
                 return WatchBreakpoint(ui,expr)
             elif type == 'exception':
                 if len(arg_parts) == 0:
-                    raise BreakpointError("Exception breakpoints " +\
+                    raise error.BreakpointError("Exception breakpoints " +\
                             "require an exception name to be specified")
                 return ExceptionBreakpoint(ui,arg_parts[0])
             elif type == 'return':
                 l = len(arg_parts)
                 if l == 0:
-                    raise BreakpointError("Return breakpoints " +\
+                    raise error.BreakpointError("Return breakpoints " +\
                             "require a function name to be specified")
                 return ReturnBreakpoint(ui,arg_parts[0])
             elif type == 'call':
                 l = len(arg_parts)
                 if l == 0:
-                    raise BreakpointError("Call breakpoints " +\
+                    raise error.BreakpointError("Call breakpoints " +\
                             "require a function name to be specified")
                 return CallBreakpoint(ui,arg_parts[0])
             else:
-                raise BreakpointError("Unknown breakpoint type, " +\
+                raise error.BreakpointError("Unknown breakpoint type, " +\
                         "please choose one of: conditional, exception,"+\
                         "call or return")
 

--- a/plugin/python/vdebug/breakpoint.py
+++ b/plugin/python/vdebug/breakpoint.py
@@ -1,7 +1,7 @@
 import base64
 
-import vdebug.log
-import vdebug.util
+from . import log
+from . import util
 
 class Store:
 
@@ -13,7 +13,7 @@ class Store:
         self.api = api
         num_bps = len(self.breakpoints)
         if num_bps > 0:
-            vdebug.log.Log("Registering %i breakpoints with the debugger" % num_bps)
+            log.Log("Registering %i breakpoints with the debugger" % num_bps)
         for id, bp in self.breakpoints.items():
             res = self.api.breakpoint_set(bp.get_cmd())
             bp.set_debugger_id(res.get_id())
@@ -23,7 +23,7 @@ class Store:
         for id, line in lines.items():
             try:
                 self.breakpoints[id].set_line(line)
-                vdebug.log.Log("Updated line number of breakpoint %s to %s"\
+                log.Log("Updated line number of breakpoint %s to %s"\
                                     %(str(id),str(line)) )
             except ValueError:
                 pass
@@ -33,7 +33,7 @@ class Store:
         self.api = None
 
     def add_breakpoint(self,breakpoint):
-        vdebug.log.Log("Adding " + str(breakpoint))
+        log.Log("Adding " + str(breakpoint))
         self.breakpoints[str(breakpoint.get_id())] = breakpoint
         breakpoint.on_add()
         if self.api is not None:
@@ -48,7 +48,7 @@ class Store:
         id = str(id)
         if id not in self.breakpoints:
             raise BreakpointError("No breakpoint matching ID %s" % id)
-        vdebug.log.Log("Removing breakpoint id %s" % id)
+        log.Log("Removing breakpoint id %s" % id)
         if self.api is not None:
             dbg_id = self.breakpoints[id].get_debugger_id()
             if dbg_id is not None:
@@ -123,7 +123,7 @@ class Breakpoint:
                 if len(line.strip()) == 0:
                     raise BreakpointError('Cannot set a breakpoint ' +\
                                             'on an empty line')
-            except vdebug.util.FilePathError:
+            except util.FilePathError:
                 raise BreakpointError('No file, cannot set breakpoint')
             return LineBreakpoint(ui,file,row)
         else:
@@ -143,7 +143,7 @@ class Breakpoint:
                     raise BreakpointError("Watch breakpoints " +\
                             "require a condition to be specified")
                 expr = " ".join(arg_parts)
-                vdebug.log.Log("Expression: %s"%expr)
+                log.Log("Expression: %s"%expr)
                 return WatchBreakpoint(ui,expr)
             elif type == 'exception':
                 if len(arg_parts) == 0:

--- a/plugin/python/vdebug/breakpoint.py
+++ b/plugin/python/vdebug/breakpoint.py
@@ -1,5 +1,6 @@
 import base64
 import vdebug.log
+import vdebug.util
 
 class Store:
 

--- a/plugin/python/vdebug/breakpoint.py
+++ b/plugin/python/vdebug/breakpoint.py
@@ -1,4 +1,5 @@
 import base64
+
 import vdebug.log
 import vdebug.util
 

--- a/plugin/python/vdebug/connection.py
+++ b/plugin/python/vdebug/connection.py
@@ -1,6 +1,5 @@
 from __future__ import print_function
 
-import os
 try:
     import queue
 except ImportError:

--- a/plugin/python/vdebug/connection.py
+++ b/plugin/python/vdebug/connection.py
@@ -9,7 +9,7 @@ import sys
 import threading
 import time
 
-import vdebug.log
+from . import log
 
 class ConnectionHandler:
     """Handles read and write operations to a given socket."""
@@ -31,8 +31,8 @@ class ConnectionHandler:
 
     def close(self):
         """Close the connection."""
-        vdebug.log.Log("Closing the socket",\
-                        vdebug.log.Logger.DEBUG)
+        log.Log("Closing the socket",\
+                        log.Logger.DEBUG)
         self.sock.close()
 
     def __recv_length(self):
@@ -160,7 +160,7 @@ class BackgroundSocketCreator(threading.Thread):
         threading.Thread.__init__(self)
 
     def log(self, message):
-        vdebug.log.Log(message, vdebug.log.Logger.DEBUG)
+        log.Log(message, log.Logger.DEBUG)
 
     def run(self):
         self.log("Started")

--- a/plugin/python/vdebug/dbgp.py
+++ b/plugin/python/vdebug/dbgp.py
@@ -9,7 +9,7 @@ if sys.hexversion >= 0x02050000:
 else:
     import elementtree.ElementTree as ET
 
-import vdebug.log
+from . import log
 
 """ Response objects for the DBGP module."""
 
@@ -245,12 +245,12 @@ class Api:
         send += ' -i '+ str(self.transID)
         if len(args) > 0:
             send += ' ' + args
-        vdebug.log.Log("Command: "+send,\
-                vdebug.log.Logger.DEBUG)
+        log.Log("Command: "+send,\
+                log.Logger.DEBUG)
         self.conn.send_msg(send)
         msg = self.conn.recv_msg()
-        vdebug.log.Log("Response: "+msg,\
-                vdebug.log.Logger.DEBUG)
+        log.Log("Response: "+msg,\
+                log.Logger.DEBUG)
         return res_cls(msg,cmd,args,self)
 
     def status(self):
@@ -466,8 +466,8 @@ class Connection:
     def close(self):
         """Close the connection."""
         if self.sock != None:
-            vdebug.log.Log("Closing the socket",\
-                            vdebug.log.Logger.DEBUG)
+            log.Log("Closing the socket",\
+                            log.Logger.DEBUG)
             self.sock.close()
             self.sock = None
         self.isconned = 0

--- a/plugin/python/vdebug/dbgp.py
+++ b/plugin/python/vdebug/dbgp.py
@@ -1,13 +1,15 @@
 from __future__ import print_function
+
+import base64
+import socket
 import sys
+import time
 if sys.hexversion >= 0x02050000:
     import xml.etree.ElementTree as ET
 else:
     import elementtree.ElementTree as ET
-import socket
+
 import vdebug.log
-import base64
-import time
 
 """ Response objects for the DBGP module."""
 

--- a/plugin/python/vdebug/debugger_interface.py
+++ b/plugin/python/vdebug/debugger_interface.py
@@ -1,5 +1,4 @@
 import vdebug.event
-import vdebug.listener
 import vdebug.session
 import vdebug.util
 import vdebug.breakpoint

--- a/plugin/python/vdebug/debugger_interface.py
+++ b/plugin/python/vdebug/debugger_interface.py
@@ -1,10 +1,11 @@
-import vdebug.event
-import vdebug.session
-import vdebug.util
-import vdebug.breakpoint
-import vdebug.ui.vimui
-import vdebug.opts
 import vim
+
+import vdebug.breakpoint
+import vdebug.event
+import vdebug.opts
+import vdebug.session
+import vdebug.ui.vimui
+import vdebug.util
 
 class DebuggerInterface:
     """Provides all methods used to control the debugger."""

--- a/plugin/python/vdebug/debugger_interface.py
+++ b/plugin/python/vdebug/debugger_interface.py
@@ -1,28 +1,28 @@
 import vim
 
-import vdebug.breakpoint
-import vdebug.event
-import vdebug.opts
-import vdebug.session
-import vdebug.ui.vimui
-import vdebug.util
+from . import breakpoint
+from . import event
+from . import opts
+from . import session
+from . import util
+from .ui import vimui
 
 class DebuggerInterface:
     """Provides all methods used to control the debugger."""
     def __init__(self):
-        self.breakpoints = vdebug.breakpoint.Store()
-        self.ui = vdebug.ui.vimui.Ui()
+        self.breakpoints = breakpoint.Store()
+        self.ui = vimui.Ui()
 
-        self.session_handler = vdebug.session.SessionHandler(self.ui,
+        self.session_handler = session.SessionHandler(self.ui,
                                     self.breakpoints)
-        self.event_dispatcher = vdebug.event.Dispatcher(self.session_handler)
+        self.event_dispatcher = event.Dispatcher(self.session_handler)
 
     def __del__(self):
         self.session_handler.stop()
         self.session_handler = None
 
     def reload_options(self):
-        vdebug.util.Environment.reload()
+        util.Environment.reload()
 
     def reload_keymappings(self):
         self.session_handler.dispatch_event("reload_keymappings")
@@ -68,12 +68,12 @@ class DebuggerInterface:
         """Set an option, overwriting the existing value.
         """
         if value is None:
-            return self.ui.say(vdebug.opts.Options.get(option))
+            return self.ui.say(opts.Options.get(option))
         else:
             self.ui.say("Setting vdebug option '%s' to: %s"\
                                 %(option,value))
             vim.command('let g:vdebug_options["%s"] = "%s"' %(option,value))
-            return vdebug.opts.Options.overwrite(option,value)
+            return opts.Options.overwrite(option,value)
 
     def handle_return_keypress(self):
         """React to a <enter> keypress event.

--- a/plugin/python/vdebug/error.py
+++ b/plugin/python/vdebug/error.py
@@ -1,0 +1,22 @@
+"""Exception classes for Vdebug."""
+
+class BreakpointError(Exception):
+    pass
+
+class UserInterrupt(Exception):
+    """Raised when a user interrupts connection wait."""
+
+class FilePathError(Exception):
+    pass
+
+class EventError(Exception):
+    pass
+
+class LogError(Exception):
+    pass
+
+class ModifiedBufferError(Exception):
+    pass
+
+class NoConnectionError(Exception):
+    pass

--- a/plugin/python/vdebug/event.py
+++ b/plugin/python/vdebug/event.py
@@ -2,6 +2,10 @@
 from __future__ import print_function
 import vdebug.log
 import vdebug.opts
+import vdebug.util
+import vdebug.ui.vimui
+import vdebug.breakpoint
+import vdebug.dbgp
 import vim
 import re
 

--- a/plugin/python/vdebug/event.py
+++ b/plugin/python/vdebug/event.py
@@ -7,6 +7,7 @@ import vim
 
 from . import breakpoint
 from . import dbgp
+from . import error
 from . import log
 from . import opts
 from . import util
@@ -133,7 +134,7 @@ class WatchWindowPropertyGetEvent(Event):
 
         eq_index = line.find('=')
         if eq_index == -1:
-            raise EventError("Cannot read the selected property")
+            raise error.EventError("Cannot read the selected property")
 
         name = line[pointer_index+step:eq_index-1]
         context_res = self.api.property_get(name)
@@ -194,7 +195,7 @@ class WatchWindowContextChangeEvent(Event):
 
         if tab_end_pos == -1 or \
                 tab_start_pos == -1:
-            raise EventError("Failed to find context name under cursor")
+            raise error.EventError("Failed to find context name under cursor")
 
         context_name = line[tab_start_pos:tab_end_pos]
         log.Log("Context name: %s" % context_name,\
@@ -207,7 +208,7 @@ class WatchWindowContextChangeEvent(Event):
                 self.session.context_names, context_name)
 
         if context_id == -1:
-            raise EventError("Could not resolve context name")
+            raise error.EventError("Could not resolve context name")
             return False
         else:
             self.dispatch("get_context", context_id)
@@ -243,9 +244,6 @@ class WatchWindowContextChangeEvent(Event):
                 found_id = id
                 break
         return found_id
-
-class EventError(Exception):
-    pass
 
 class RefreshEvent(Event):
     def run(self, status):

--- a/plugin/python/vdebug/event.py
+++ b/plugin/python/vdebug/event.py
@@ -1,13 +1,16 @@
 # coding=utf-8
 from __future__ import print_function
-import vdebug.log
-import vdebug.opts
-import vdebug.util
-import vdebug.ui.vimui
+
+import re
+
+import vim
+
 import vdebug.breakpoint
 import vdebug.dbgp
-import vim
-import re
+import vdebug.log
+import vdebug.opts
+import vdebug.ui.vimui
+import vdebug.util
 
 class Event:
     def __init__(self, session_handler):

--- a/plugin/python/vdebug/listener.py
+++ b/plugin/python/vdebug/listener.py
@@ -1,7 +1,8 @@
+import vim
+
 import vdebug.connection
 import vdebug.opts
 import vdebug.util
-import vim
 
 class Listener:
     @classmethod

--- a/plugin/python/vdebug/listener.py
+++ b/plugin/python/vdebug/listener.py
@@ -1,25 +1,25 @@
 import vim
 
-import vdebug.connection
-import vdebug.opts
-import vdebug.util
+from . import connection
+from . import opts
+from . import util
 
 class Listener:
     @classmethod
     def create(cls):
-        if vdebug.opts.Options.get('background_listener', int):
+        if opts.Options.get('background_listener', int):
             return BackgroundListener()
         else:
             return ForegroundListener()
 
 class ForegroundListener:
     def __init__(self):
-        self.__server = vdebug.connection.SocketCreator(vdebug.util.InputStream())
+        self.__server = connection.SocketCreator(util.InputStream())
 
     def start(self):
-        self.__server.start(vdebug.opts.Options.get('server'),
-                            vdebug.opts.Options.get('port', int),
-                            vdebug.opts.Options.get('timeout', int))
+        self.__server.start(opts.Options.get('server'),
+                            opts.Options.get('port', int),
+                            opts.Options.get('timeout', int))
 
     def stop(self):
         self.__server.clear()
@@ -34,28 +34,28 @@ class ForegroundListener:
         return "inactive"
 
     def create_connection(self):
-        handler = vdebug.connection.ConnectionHandler(*self.__server.socket())
+        handler = connection.ConnectionHandler(*self.__server.socket())
         self.stop()
         return handler
 
 class BackgroundListener:
 
     def __init__(self):
-        self.__server = vdebug.connection.SocketServer()
+        self.__server = connection.SocketServer()
 
     def start(self):
-        if vdebug.opts.Options.get("auto_start", int):
+        if opts.Options.get("auto_start", int):
             vim.command('au CursorHold * python debugger.start_if_ready()')
             vim.command('au CursorHoldI * python debugger.start_if_ready()')
             vim.command('au CursorMoved * python debugger.start_if_ready()')
             vim.command('au CursorMovedI * python debugger.start_if_ready()')
             vim.command('au FocusGained * python debugger.start_if_ready()')
             vim.command('au FocusLost * python debugger.start_if_ready()')
-        self.__server.start(vdebug.opts.Options.get('server'),
-                            vdebug.opts.Options.get('port', int))
+        self.__server.start(opts.Options.get('server'),
+                            opts.Options.get('port', int))
 
     def stop(self):
-        if vdebug.opts.Options.get("auto_start", bool):
+        if opts.Options.get("auto_start", bool):
             vim.command('au! CursorHold *')
             vim.command('au! CursorHoldI *')
             vim.command('au! CursorMoved *')
@@ -81,6 +81,6 @@ class BackgroundListener:
         return not self.is_ready() and self.__server.is_alive()
 
     def create_connection(self):
-        handler = vdebug.connection.ConnectionHandler(*self.__server.socket())
+        handler = connection.ConnectionHandler(*self.__server.socket())
         self.stop()
         return handler

--- a/plugin/python/vdebug/log.py
+++ b/plugin/python/vdebug/log.py
@@ -75,10 +75,10 @@ class FileLogger(Logger):
         try:
             self.f = open(self.filename,'w')
         except IOError as e:
-            raise LogError("Invalid file name '%s' for log file: %s" \
+            raise error.LogError("Invalid file name '%s' for log file: %s" \
                     %(self.filename,str(e)))
         except:
-            raise LogError("Error using file '%s' as a log file: %s" \
+            raise error.LogError("Error using file '%s' as a log file: %s" \
                     %(self.filename,sys.exc_info()[0]))
 
 
@@ -128,7 +128,4 @@ class Log:
         for k, l in cls.loggers.items():
             l.shutdown()
         cls.loggers = {}
-
-class LogError(Exception):
-    pass
 

--- a/plugin/python/vdebug/log.py
+++ b/plugin/python/vdebug/log.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
-import time
-import sys
+
 import os
+import sys
+import time
 
 class Logger:
     """ Abstract class for all logger implementations.

--- a/plugin/python/vdebug/session.py
+++ b/plugin/python/vdebug/session.py
@@ -1,12 +1,15 @@
 from __future__ import print_function
-import vdebug.util
-import vdebug.opts
-import vdebug.log
-import vdebug.dbgp
-import vdebug.listener
-import vdebug.event
-import vim
+
 import socket
+
+import vim
+
+import vdebug.dbgp
+import vdebug.event
+import vdebug.listener
+import vdebug.log
+import vdebug.opts
+import vdebug.util
 
 class ModifiedBufferError(Exception):
     pass

--- a/plugin/python/vdebug/session.py
+++ b/plugin/python/vdebug/session.py
@@ -5,17 +5,12 @@ import socket
 import vim
 
 from . import dbgp
+from . import error
 from . import event
 from . import listener
 from . import log
 from . import opts
 from . import util
-
-class ModifiedBufferError(Exception):
-    pass
-
-class NoConnectionError(Exception):
-    pass
 
 class SessionHandler:
     def __init__(self, ui, breakpoints):
@@ -187,7 +182,7 @@ class Session:
     def start(self, connection):
         util.Environment.reload()
         if self.__ui.is_modified():
-            raise ModifiedBufferError("Modified buffers must be saved before debugging")
+            raise error.ModifiedBufferError("Modified buffers must be saved before debugging")
 
         try:
             self.__api = dbgp.Api(connection)

--- a/plugin/python/vdebug/session.py
+++ b/plugin/python/vdebug/session.py
@@ -4,6 +4,7 @@ import vdebug.opts
 import vdebug.log
 import vdebug.dbgp
 import vdebug.listener
+import vdebug.event
 import vim
 import socket
 

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -3,10 +3,10 @@ from __future__ import print_function
 
 import vim
 
-import vdebug.log
-import vdebug.opts
-import vdebug.ui.interface
-import vdebug.util
+from . import interface
+from .. import log
+from .. import opts
+from .. import util
 
 class WindowError(Exception):
     pass
@@ -33,13 +33,13 @@ class WindowManager:
 
     def open_all(self):
         self._refresh_commands()
-        arrangement = vdebug.opts.Options.get('window_arrangement', list)
+        arrangement = opts.Options.get('window_arrangement', list)
         for name in arrangement:
             self.window(name).create(self._command(name))
 
     def open(self, name):
         if not self.window(name).is_open:
-            vdebug.log.Log("Creating window %s" %name)
+            log.Log("Creating window %s" %name)
             self.window(name).create(self._command(name))
 
     def toggle(self, name):
@@ -83,14 +83,14 @@ class WindowManager:
 
     def _refresh_commands(self):
         self._commands = self._default_commands.copy()
-        self._commands.update(vdebug.opts.Options.get('window_commands', dict))
+        self._commands.update(opts.Options.get('window_commands', dict))
 
-class Ui(vdebug.ui.interface.Ui):
+class Ui(interface.Ui):
     """Ui layer which manages the Vim windows.
     """
 
     def __init__(self):
-        vdebug.ui.interface.Ui.__init__(self)
+        interface.Ui.__init__(self)
         self.is_open = False
         self.emptybuffer = None
         self.windows = WindowManager()
@@ -141,9 +141,9 @@ class Ui(vdebug.ui.interface.Ui):
             statuswin = self.windows.status()
             statuswin.set_status("loading")
 
-            vdebug.log.Log.set_logger(
-                    vdebug.log.WindowLogger(
-                        vdebug.opts.Options.get('debug_window_level'),
+            log.Log.set_logger(
+                    log.WindowLogger(
+                        opts.Options.get('debug_window_level'),
                         self.windows.log()
                     ))
 
@@ -175,7 +175,7 @@ class Ui(vdebug.ui.interface.Ui):
         self.windows.status().set_status(status)
 
     def get_current_file(self):
-        return vdebug.util.LocalFilePath(vim.current.buffer.name)
+        return util.LocalFilePath(vim.current.buffer.name)
 
     def get_current_row(self):
         return vim.current.window.cursor[0]
@@ -222,14 +222,14 @@ class Ui(vdebug.ui.interface.Ui):
     def say(self, string):
         """ Vim picks up Python prints, so just print """
         print(string)
-        vdebug.log.Log(string,vdebug.log.Logger.INFO)
+        log.Log(string,log.Logger.INFO)
 
     def error(self,string):
         self._last_error = string
         vim.command('echohl Error | echomsg "'+\
                 str(string).replace('"','\\"')+\
                 '" | echohl None')
-        vdebug.log.Log(string,vdebug.log.Logger.ERROR)
+        log.Log(string,log.Logger.ERROR)
 
     def get_last_error(self):
         return self._last_error
@@ -239,7 +239,7 @@ class Ui(vdebug.ui.interface.Ui):
             return
         self.is_open = False
 
-        vdebug.log.Log.remove_logger('WindowLogger')
+        log.Log.remove_logger('WindowLogger')
         if self.tabnr:
             vim.command('silent! %stabc!' % self.tabnr)
         if self.current_tab:
@@ -255,24 +255,24 @@ class Ui(vdebug.ui.interface.Ui):
 
     def __get_srcwinno_by_name(self, name):
         i = 1
-        vdebug.log.Log("Searching for win by name %s" % name,\
-                vdebug.log.Logger.INFO)
+        log.Log("Searching for win by name %s" % name,\
+                log.Logger.INFO)
         for w in vim.windows:
-            vdebug.log.Log("Win %d, name %s" %(i, w.buffer.name),\
-                vdebug.log.Logger.INFO)
+            log.Log("Win %d, name %s" %(i, w.buffer.name),\
+                log.Logger.INFO)
             if w.buffer.name == name:
                 break
             else:
                 i += 1
 
-        vdebug.log.Log("Returning window number %d" % i,\
-                vdebug.log.Logger.INFO)
+        log.Log("Returning window number %d" % i,\
+                log.Logger.INFO)
         return i
 
     def __get_buf_list(self):
         return vim.eval("range(1, bufnr('$'))")
 
-class SourceWindow(vdebug.ui.interface.Window):
+class SourceWindow(interface.Window):
 
     file = None
     pointer_sign_id = '6145'
@@ -298,26 +298,26 @@ class SourceWindow(vdebug.ui.interface.Window):
         if file == self.file:
             return
         self.file = file
-        vdebug.log.Log("Setting source file: %s" % file,vdebug.log.Logger.INFO)
+        log.Log("Setting source file: %s" % file,log.Logger.INFO)
         self.focus()
         vim.command('call Vdebug_edit("%s")' % str(file).replace("\\", "\\\\"))
 
     def set_line(self,lineno):
-        vdebug.log.Log("Setting source line number: %s" % lineno,vdebug.log.Logger.DEBUG)
+        log.Log("Setting source line number: %s" % lineno,log.Logger.DEBUG)
         self.focus()
         vim.command(":%s" % str(lineno))
 
     def get_file(self):
         self.focus()
-        self.file = vdebug.util.LocalFilePath(vim.eval("expand('%:p')"))
+        self.file = util.LocalFilePath(vim.eval("expand('%:p')"))
         return self.file
 
     def clear_signs(self):
         vim.command('sign unplace *')
 
     def place_pointer(self,line):
-        vdebug.log.Log("Placing pointer sign on line "+str(line),\
-                vdebug.log.Logger.INFO)
+        log.Log("Placing pointer sign on line "+str(line),\
+                log.Logger.INFO)
         self.remove_pointer()
         vim.command('sign place '+self.pointer_sign_id+\
                 ' name=current line='+str(line)+\
@@ -396,8 +396,8 @@ class VimBuffer:
 class HiddenBuffer:
     def __init__(self, buffer = []):
         self._buffer = buffer
-        vdebug.log.Log("Creating hidden buffer: %s" % buffer,
-                vdebug.log.Logger.DEBUG)
+        log.Log("Creating hidden buffer: %s" % buffer,
+                log.Logger.DEBUG)
 
     def line(self, number):
         return self._buffer[number]
@@ -424,8 +424,8 @@ class HiddenBuffer:
                 from_line = lineno
                 to_line = lineno
             self._buffer[from_line:to_line] = str(msg).split('\n')
-        vdebug.log.Log("Hidden buffer after insert: %s" %(self._buffer),
-                vdebug.log.Logger.DEBUG)
+        log.Log("Hidden buffer after insert: %s" %(self._buffer),
+                log.Logger.DEBUG)
 
     def delete(self, start_line, end_line = None):
         try:
@@ -444,7 +444,7 @@ class HiddenBuffer:
     def is_empty(self):
         return not self._buffer
 
-class Window(vdebug.ui.interface.Window):
+class Window(interface.Window):
     name = "WINDOW"
     creation_count = 0
 
@@ -493,8 +493,8 @@ class Window(vdebug.ui.interface.Window):
         vim.command("setlocal buftype=nofile modifiable "+ \
                 "winfixheight winfixwidth nonumber norelativenumber")
         existing_content = self._buffer.contents()
-        vdebug.log.Log("Setting buffer for %s: %s" %(self.name, existing_content),
-                vdebug.log.Logger.DEBUG)
+        log.Log("Setting buffer for %s: %s" %(self.name, existing_content),
+                log.Logger.DEBUG)
         self._buffer = VimBuffer(vim.current.buffer)
         self._buffer.overwrite(existing_content)
         self.is_open = True
@@ -632,7 +632,7 @@ class StatusWindow(Window):
     def on_create(self):
         self.command('setlocal syntax=debugger_status')
         if self._buffer.is_empty():
-            keys = vdebug.util.Keymapper()
+            keys = util.Keymapper()
             output = "Status: starting\nListening on port\nNot connected\n\n"
             output += "Press %s to start debugging, " %(keys.run_key())
             output += "%s to stop/close. " %(keys.close_key())
@@ -709,7 +709,7 @@ class StackGetResponseRenderer(ResponseRenderer):
                 where = s.get('where')
             else:
                 where = 'main'
-            file = vdebug.util.FilePath(s.get('filename'))
+            file = util.FilePath(s.get('filename'))
             line = "[%(num)s] %(where)s @ %(file)s:%(line)s" \
                     %{'num':s.get('level'),'where':where,\
                     'file':str(file.as_local()),'line':s.get('lineno')}
@@ -733,8 +733,8 @@ class ContextGetResponseRenderer(ResponseRenderer):
 
         properties = self.response.get_context()
         num_props = len(properties)
-        vdebug.log.Log("Writing %i properties to the window" % num_props,\
-                vdebug.log.Logger.INFO )
+        log.Log("Writing %i properties to the window" % num_props,\
+                log.Logger.INFO )
         for idx, prop in enumerate(properties):
             final = False
             try:
@@ -744,7 +744,7 @@ class ContextGetResponseRenderer(ResponseRenderer):
                 next_prop = None
             res += self.__render_property(prop,next_prop,final,indent)
 
-        vdebug.log.Log("Writing to window:\n"+res,vdebug.log.Logger.DEBUG)
+        log.Log("Writing to window:\n"+res,log.Logger.DEBUG)
 
         return res
 
@@ -770,7 +770,7 @@ class ContextGetResponseRenderer(ResponseRenderer):
                         "\\n'\n%(indent)s'"%{'indent':indent_str})}
         line = line.rstrip() + "\n"
 
-        if vdebug.opts.Options.get('watch_window_style') == 'expanded':
+        if opts.Options.get('watch_window_style') == 'expanded':
             depth = p.depth
             if next_p and not last:
                 next_depth = next_p.depth
@@ -796,10 +796,10 @@ class ContextGetResponseRenderer(ResponseRenderer):
         return line
 
     def __get_marker(self,property):
-        char = vdebug.opts.Options.get('marker_default')
+        char = opts.Options.get('marker_default')
         if property.has_children:
             if property.child_count() == 0:
-                char = vdebug.opts.Options.get('marker_closed_tree')
+                char = opts.Options.get('marker_closed_tree')
             else:
-                char = vdebug.opts.Options.get('marker_open_tree')
+                char = opts.Options.get('marker_open_tree')
         return char

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -1,10 +1,12 @@
 # coding=utf-8
 from __future__ import print_function
-import vdebug.ui.interface
-import vdebug.util
+
 import vim
+
 import vdebug.log
 import vdebug.opts
+import vdebug.ui.interface
+import vdebug.util
 
 class WindowError(Exception):
     pass

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -13,21 +13,21 @@ except ImportError:
 
 import vim
 
-import vdebug.breakpoint
-import vdebug.dbgp
-import vdebug.event
-import vdebug.log
-import vdebug.opts
-import vdebug.session
+from . import breakpoint
+from . import dbgp
+from . import event
+from . import log
+from . import opts
+from . import session
 
 class ExceptionHandler:
     def __init__(self, session_handler):
         self._session_handler = session_handler
-        self.readable_errors = (vdebug.event.EventError,
-                vdebug.breakpoint.BreakpointError,
-                vdebug.log.LogError,
-                vdebug.session.NoConnectionError,
-                vdebug.session.ModifiedBufferError)
+        self.readable_errors = (event.EventError,
+                breakpoint.BreakpointError,
+                log.LogError,
+                session.NoConnectionError,
+                session.ModifiedBufferError)
 
 
     """ Exception handlers """
@@ -84,16 +84,16 @@ class ExceptionHandler:
     def handle(self, e):
         """Switch on the exception type to work out how to handle it.
         """
-        if isinstance(e, vdebug.dbgp.TimeoutError):
+        if isinstance(e, dbgp.TimeoutError):
             self.handle_timeout()
-        elif isinstance(e, vdebug.util.UserInterrupt):
+        elif isinstance(e, UserInterrupt):
             try:
                 self.handle_interrupt()
             except:
                 pass
         elif isinstance(e, self.readable_errors):
             self.handle_readable_error(e)
-        elif isinstance(e, vdebug.dbgp.DBGPError):
+        elif isinstance(e, dbgp.DBGPError):
             self.handle_dbgp_error(e)
         elif isinstance(e, (EOFError,socket.error)):
             self.handle_socket_end()
@@ -165,8 +165,8 @@ class Keymapper:
                 if p in special:
                     continue
                 elif p in keys:
-                    vdebug.log.Log("Storing existing key mapping, '%s' " % line,
-                                   vdebug.log.Logger.DEBUG)
+                    log.Log("Storing existing key mapping, '%s' " % line,
+                                   log.Logger.DEBUG)
                     self.existing.append(line)
                 else:
                     break
@@ -181,8 +181,8 @@ class Keymapper:
                 if func not in self.exclude:
                     vim.command("unmap %s%s" %(self.leader,key))
             for mapping in self.existing:
-                vdebug.log.Log("Remapping key with '%s' " % mapping,\
-                        vdebug.log.Logger.DEBUG)
+                log.Log("Remapping key with '%s' " % mapping,\
+                        log.Logger.DEBUG)
                 vim.command(mapping)
 
 class FilePath:
@@ -217,13 +217,13 @@ class FilePath:
         """
         ret = f
 
-        if vdebug.opts.Options.isset('path_maps'):
-            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).items(), key=lambda l: len(l[0]), reverse=True)
+        if opts.Options.isset('path_maps'):
+            sorted_path_maps = sorted(opts.Options.get('path_maps', dict).items(), key=lambda l: len(l[0]), reverse=True)
             for remote, local in sorted_path_maps:
                 if remote in ret:
-                    vdebug.log.Log("Replacing remote path (%s) " % remote +\
+                    log.Log("Replacing remote path (%s) " % remote +\
                             "with local path (%s)" % local ,\
-                            vdebug.log.Logger.DEBUG)
+                            log.Logger.DEBUG)
                     ret = ret.replace(remote,local,1)
 
                     # determine remote path separator and replace by local
@@ -242,13 +242,13 @@ class FilePath:
         """
         ret = f
 
-        if vdebug.opts.Options.isset('path_maps'):
-            sorted_path_maps = sorted(vdebug.opts.Options.get('path_maps', dict).items(), key=lambda l: len(l[0]), reverse=True)
+        if opts.Options.isset('path_maps'):
+            sorted_path_maps = sorted(opts.Options.get('path_maps', dict).items(), key=lambda l: len(l[0]), reverse=True)
             for remote, local in sorted_path_maps:
                 if local in ret:
-                    vdebug.log.Log("Replacing local path (%s) " % local +\
+                    log.Log("Replacing local path (%s) " % local +\
                             "with remote path (%s)" % remote ,\
-                            vdebug.log.Logger.DEBUG)
+                            log.Logger.DEBUG)
                     ret = ret.replace(local,remote,1)
                     # replace remaining local separators with URL '/' separators
                     ret = ret.replace('\\', '/')
@@ -316,11 +316,11 @@ class RemoteFilePath(FilePath):
 
 class Environment:
     @staticmethod
-    def reload(options = vdebug.opts.Options):
+    def reload(options = opts.Options):
         options.set(vim.eval('g:vdebug_options'))
 
         if options.isset('debug_file'):
-            vdebug.log.Log.set_logger(vdebug.log.FileLogger(\
+            log.Log.set_logger(log.FileLogger(\
                     options.get('debug_file_level'),\
                     options.get('debug_file')))
 

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -6,6 +6,7 @@ import socket
 import sys
 import time
 import traceback
+import urllib
 try:
     import urllib.parse as urllib
 except ImportError:
@@ -13,10 +14,12 @@ except ImportError:
 
 import vim
 
-import vdebug.opts
-import vdebug.log
-import vdebug.session
 import vdebug.breakpoint
+import vdebug.dbgp
+import vdebug.event
+import vdebug.log
+import vdebug.opts
+import vdebug.session
 
 class ExceptionHandler:
     def __init__(self, session_handler):

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -6,7 +6,6 @@ import socket
 import sys
 import time
 import traceback
-import urllib
 try:
     import urllib.parse as urllib
 except ImportError:

--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -13,21 +13,19 @@ except ImportError:
 
 import vim
 
-from . import breakpoint
 from . import dbgp
-from . import event
+from . import error
 from . import log
 from . import opts
-from . import session
 
 class ExceptionHandler:
     def __init__(self, session_handler):
         self._session_handler = session_handler
-        self.readable_errors = (event.EventError,
-                breakpoint.BreakpointError,
-                log.LogError,
-                session.NoConnectionError,
-                session.ModifiedBufferError)
+        self.readable_errors = (error.EventError,
+                error.BreakpointError,
+                error.LogError,
+                error.NoConnectionError,
+                error.ModifiedBufferError)
 
 
     """ Exception handlers """
@@ -86,7 +84,7 @@ class ExceptionHandler:
         """
         if isinstance(e, dbgp.TimeoutError):
             self.handle_timeout()
-        elif isinstance(e, UserInterrupt):
+        elif isinstance(e, error.UserInterrupt):
             try:
                 self.handle_interrupt()
             except:
@@ -193,7 +191,7 @@ class FilePath:
     def __init__(self,filename):
         if filename is None or \
             len(filename) == 0:
-            raise FilePathError("Missing or invalid file name")
+            raise error.FilePathError("Missing or invalid file name")
         filename = urllib.unquote(filename)
         if filename.startswith('file:'):
             filename = filename[5:]
@@ -324,9 +322,6 @@ class Environment:
                     options.get('debug_file_level'),\
                     options.get('debug_file')))
 
-class FilePathError(Exception):
-    pass
-
 class InputStream:
     """Get a character from Vim's input stream.
 
@@ -337,7 +332,5 @@ class InputStream:
             vim.eval("getchar(0)")
             time.sleep(0.1)
         except: # vim.error
-            raise UserInterrupt()
+            raise error.UserInterrupt()
 
-class UserInterrupt(Exception):
-    """Raised when a user interrupts connection wait."""

--- a/tests/test_breakpoint_breakpoint.py
+++ b/tests/test_breakpoint_breakpoint.py
@@ -3,6 +3,7 @@ if __name__ == "__main__":
     sys.path.append('../plugin/python/')
 import unittest
 import vdebug.breakpoint
+import vdebug.error
 import vdebug.util
 import base64
 from mock import Mock
@@ -118,7 +119,7 @@ class BreakpointTest(unittest.TestCase):
         Mock.__len__ = Mock(return_value=0)
         ui = Mock()
         re = 'Cannot set a breakpoint on an empty line'
-        self.assertRaisesRegexp(vdebug.breakpoint.BreakpointError,\
+        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
                 re,vdebug.breakpoint.Breakpoint.parse,ui,"")
 
     def test_parse_with_conditional_breakpoint(self):
@@ -134,7 +135,7 @@ class BreakpointTest(unittest.TestCase):
         args = "conditional"
         re = "Conditional breakpoints require a condition "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.breakpoint.BreakpointError,\
+        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 
     def test_parse_with_exception_breakpoint(self):
@@ -150,7 +151,7 @@ class BreakpointTest(unittest.TestCase):
         args = "exception"
         re = "Exception breakpoints require an exception name "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.breakpoint.BreakpointError,\
+        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 
 
@@ -167,7 +168,7 @@ class BreakpointTest(unittest.TestCase):
         args = "call"
         re = "Call breakpoints require a function name "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.breakpoint.BreakpointError,\
+        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 
     def test_parse_with_return_breakpoint(self):
@@ -183,6 +184,6 @@ class BreakpointTest(unittest.TestCase):
         args = "return"
         re = "Return breakpoints require a function name "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.breakpoint.BreakpointError,\
+        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -3,7 +3,8 @@ if __name__ == "__main__":
     sys.path.append('../plugin/python/')
 import unittest
 import vdebug.opts
-from vdebug.util import FilePath,FilePathError
+from vdebug.util import FilePath
+from vdebug.error import FilePathError
 
 class LocalFilePathTest(unittest.TestCase):
 


### PR DESCRIPTION
* import names that are used but not imported (no idea why it did work before)
* format and sort imports in accordance with pep8
* use relative imports for vdebug files
* prepare for py3 with absolute_import and new names from the stdlib