### PR TITLE
Close connection automatically when the script has finished running

### DIFF
--- a/plugin/python/vdebug/runner.py
+++ b/plugin/python/vdebug/runner.py
@@ -110,7 +110,7 @@ class Runner:
             elif str(status) in ("stopping","stopped"):
                 self.ui.statuswin.set_status("stopped")
                 self.ui.say("Debugging session has ended")
-                self.close_connection(False)
+                self.close_connection(True)
                 if vdebug.opts.Options.get('continuous_mode', int) != 0:
                     self.open()
                     return


### PR DESCRIPTION
Not sure if there's a reason for the connection to stay open when the script has completed running. This ensures that the open socket on the remote script will not be left open when the debugging ends. Is there a reason that this was initially set to False?