### PR TITLE
Pad the local and remote if they do not have a trailing slash

### DIFF
--- a/pythonx/vdebug/util.py
+++ b/pythonx/vdebug/util.py
@@ -222,6 +222,8 @@ class FilePath:
                 if remote in ret:
                     log.Log("Replacing remote path (%s) with local path (%s)"
                             % (remote, local), log.Logger.DEBUG)
+                    if not local.endswith('/'):
+                        local = local+'/'
                     ret = ret.replace(remote, local, 1)
 
                     # determine remote path separator and replace by local
@@ -249,6 +251,8 @@ class FilePath:
                 if local in ret:
                     log.Log("Replacing local path (%s) with remote path (%s)"
                             % (local, remote), log.Logger.DEBUG)
+                    if not remote.endswith('/'):
+                        remote = remote+'/'
                     ret = ret.replace(local, remote, 1)
                     # replace remaining local separators with URL '/' separators
                     ret = ret.replace('\\', '/')

--- a/pythonx/vdebug/util.py
+++ b/pythonx/vdebug/util.py
@@ -222,8 +222,10 @@ class FilePath:
                 if remote in ret:
                     log.Log("Replacing remote path (%s) with local path (%s)"
                             % (remote, local), log.Logger.DEBUG)
-                    if not local.endswith('/'):
+                    if not local.endswith('/') and remote.endswith('/'):
                         local = local+'/'
+                    elif local.endswith('/') and not remote.endswith('/'):
+                        local = local[:-1]
                     ret = ret.replace(remote, local, 1)
 
                     # determine remote path separator and replace by local
@@ -251,8 +253,10 @@ class FilePath:
                 if local in ret:
                     log.Log("Replacing local path (%s) with remote path (%s)"
                             % (local, remote), log.Logger.DEBUG)
-                    if not remote.endswith('/'):
+                    if not remote.endswith('/') and local.endswith('/'):
                         remote = remote+'/'
+                    elif remote.endswith('/') and not local.endswith('/'):
+                        remote = remote[:-1]
                     ret = ret.replace(local, remote, 1)
                     # replace remaining local separators with URL '/' separators
                     ret = ret.replace('\\', '/')

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -83,20 +83,20 @@ class RemotePathTest(unittest.TestCase):
     def test_as_local(self):
         filename = "/remote1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local1//path/to/file",file.as_local())
+        self.assertEqual("/local1/path/to/file",file.as_local())
 
         filename = "/remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local2//path/to/file",file.as_local())
+        self.assertEqual("/local2/path/to/file",file.as_local())
 
     def test_as_local_with_uri(self):
         filename = "file:///remote1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local1//path/to/file",file.as_local())
+        self.assertEqual("/local1/path/to/file",file.as_local())
 
         filename = "file:///remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local2//path/to/file",file.as_local())
+        self.assertEqual("/local2/path/to/file",file.as_local())
 
     def test_as_local_does_nothing(self):
         filename = "/the/remote/path/to/file"
@@ -106,29 +106,29 @@ class RemotePathTest(unittest.TestCase):
     def test_as_remote_with_unix_paths(self):
         filename = "/local1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote1//path/to/file",file.as_remote())
+        self.assertEqual("file:///remote1/path/to/file",file.as_remote())
 
         filename = "file:///local2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote2//path/to/file",file.as_remote())
+        self.assertEqual("file:///remote2/path/to/file",file.as_remote())
 
     def test_as_remote_with_win_paths(self):
         filename = "C:/local1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote1//path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote1/path/to/file",file.as_remote())
 
         filename = "file:///C:/local2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote2//path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote2/path/to/file",file.as_remote())
 
     def test_as_remote_with_backslashed_win_paths(self):
         filename = "C:\\local1\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote1//path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote1/path/to/file",file.as_remote())
 
         filename = "C:\\local2\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote2//path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote2/path/to/file",file.as_remote())
 
         filename = "C:/local2/path/to/file"
         file = FilePath(filename)
@@ -141,11 +141,11 @@ class RemoteWinLocalUnixPathTest(unittest.TestCase):
     def test_as_local(self):
         filename = "G:\\remote\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("/local/path//to/file",file.as_local())
+        self.assertEqual("/local/path/to/file",file.as_local())
 
         filename = "file:///G:/remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local2/path//to/file",file.as_local())
+        self.assertEqual("/local2/path/to/file",file.as_local())
 
     def test_as_local_does_nothing(self):
         filename = "/the/path/to/file"
@@ -155,11 +155,11 @@ class RemoteWinLocalUnixPathTest(unittest.TestCase):
     def test_as_remote(self):
         filename = "/local/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///G:/remote/path//to/file",file.as_remote())
+        self.assertEqual("file:///G:/remote/path/to/file",file.as_remote())
 
         filename = "file:///local2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///G:/remote2/path//to/file",file.as_remote())
+        self.assertEqual("file:///G:/remote2/path/to/file",file.as_remote())
 
 class RemoteUnixLocalWinPathTest(unittest.TestCase):
     def setUp(self):
@@ -168,11 +168,11 @@ class RemoteUnixLocalWinPathTest(unittest.TestCase):
     def test_as_local(self):
         filename = "/remote/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("G:\\local\\path\\\\to\\file",file.as_local())
+        self.assertEqual("G:\\local\\path\\to\\file",file.as_local())
 
         filename = "file:///remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("G:\\local2\\path\\\\to\\file",file.as_local())
+        self.assertEqual("G:\\local2\\path\\to\\file",file.as_local())
 
     def test_as_local_does_nothing(self):
         filename = "G:\\the\\path\\to\\file"
@@ -182,11 +182,11 @@ class RemoteUnixLocalWinPathTest(unittest.TestCase):
     def test_as_remote(self):
         filename = "G:\\local\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote/path//to/file",file.as_remote())
+        self.assertEqual("file:///remote/path/to/file",file.as_remote())
 
         filename = "file:///G:/local2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote2/path//to/file",file.as_remote())
+        self.assertEqual("file:///remote2/path/to/file",file.as_remote())
 
 class MismatchingSeparatorsTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -186,4 +186,26 @@ class RemoteUnixLocalWinPathTest(unittest.TestCase):
 
         filename = "file:///G:/local2/path/to/file"
         file = FilePath(filename)
+        self.assertEqual("file:///remote2/path//to/file",file.as_remote())
+
+class MismatchingSeparatorsTest(unittest.TestCase):
+    def setUp(self):
+        vdebug.opts.Options.set({'path_maps':{'remote1/':'local1', 'remote2':'local2/'}})
+
+    def test_as_local(self):
+        filename = "/remote1/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("/local1/path/to/file",file.as_local())
+
+        filename = "/remote2/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("/local2//path/to/file",file.as_local())
+
+    def test_as_remote(self):
+        filename = "/local1/path/to/file"
+        file = FilePath(filename)
+        self.assertEqual("file:///remote1//path/to/file",file.as_remote())
+
+        filename = "/local2/path/to/file"
+        file = FilePath(filename)
         self.assertEqual("file:///remote2/path/to/file",file.as_remote())

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -199,12 +199,12 @@ class MismatchingSeparatorsTest(unittest.TestCase):
 
         filename = "/remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local2//path/to/file",file.as_local())
+        self.assertEqual("/local2/path/to/file",file.as_local())
 
     def test_as_remote(self):
         filename = "/local1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote1//path/to/file",file.as_remote())
+        self.assertEqual("file:///remote1/path/to/file",file.as_remote())
 
         filename = "/local2/path/to/file"
         file = FilePath(filename)

--- a/tests/test_util_filepath.py
+++ b/tests/test_util_filepath.py
@@ -83,20 +83,20 @@ class RemotePathTest(unittest.TestCase):
     def test_as_local(self):
         filename = "/remote1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local1/path/to/file",file.as_local())
+        self.assertEqual("/local1//path/to/file",file.as_local())
 
         filename = "/remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local2/path/to/file",file.as_local())
+        self.assertEqual("/local2//path/to/file",file.as_local())
 
     def test_as_local_with_uri(self):
         filename = "file:///remote1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local1/path/to/file",file.as_local())
+        self.assertEqual("/local1//path/to/file",file.as_local())
 
         filename = "file:///remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local2/path/to/file",file.as_local())
+        self.assertEqual("/local2//path/to/file",file.as_local())
 
     def test_as_local_does_nothing(self):
         filename = "/the/remote/path/to/file"
@@ -106,29 +106,29 @@ class RemotePathTest(unittest.TestCase):
     def test_as_remote_with_unix_paths(self):
         filename = "/local1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote1/path/to/file",file.as_remote())
+        self.assertEqual("file:///remote1//path/to/file",file.as_remote())
 
         filename = "file:///local2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote2/path/to/file",file.as_remote())
+        self.assertEqual("file:///remote2//path/to/file",file.as_remote())
 
     def test_as_remote_with_win_paths(self):
         filename = "C:/local1/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote1/path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote1//path/to/file",file.as_remote())
 
         filename = "file:///C:/local2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote2/path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote2//path/to/file",file.as_remote())
 
     def test_as_remote_with_backslashed_win_paths(self):
         filename = "C:\\local1\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote1/path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote1//path/to/file",file.as_remote())
 
         filename = "C:\\local2\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("file:///C:/remote2/path/to/file",file.as_remote())
+        self.assertEqual("file:///C:/remote2//path/to/file",file.as_remote())
 
         filename = "C:/local2/path/to/file"
         file = FilePath(filename)
@@ -141,11 +141,11 @@ class RemoteWinLocalUnixPathTest(unittest.TestCase):
     def test_as_local(self):
         filename = "G:\\remote\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("/local/path/to/file",file.as_local())
+        self.assertEqual("/local/path//to/file",file.as_local())
 
         filename = "file:///G:/remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("/local2/path/to/file",file.as_local())
+        self.assertEqual("/local2/path//to/file",file.as_local())
 
     def test_as_local_does_nothing(self):
         filename = "/the/path/to/file"
@@ -155,11 +155,11 @@ class RemoteWinLocalUnixPathTest(unittest.TestCase):
     def test_as_remote(self):
         filename = "/local/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///G:/remote/path/to/file",file.as_remote())
+        self.assertEqual("file:///G:/remote/path//to/file",file.as_remote())
 
         filename = "file:///local2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("file:///G:/remote2/path/to/file",file.as_remote())
+        self.assertEqual("file:///G:/remote2/path//to/file",file.as_remote())
 
 class RemoteUnixLocalWinPathTest(unittest.TestCase):
     def setUp(self):
@@ -168,11 +168,11 @@ class RemoteUnixLocalWinPathTest(unittest.TestCase):
     def test_as_local(self):
         filename = "/remote/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("G:\\local\\path\\to\\file",file.as_local())
+        self.assertEqual("G:\\local\\path\\\\to\\file",file.as_local())
 
         filename = "file:///remote2/path/to/file"
         file = FilePath(filename)
-        self.assertEqual("G:\\local2\\path\\to\\file",file.as_local())
+        self.assertEqual("G:\\local2\\path\\\\to\\file",file.as_local())
 
     def test_as_local_does_nothing(self):
         filename = "G:\\the\\path\\to\\file"
@@ -182,7 +182,7 @@ class RemoteUnixLocalWinPathTest(unittest.TestCase):
     def test_as_remote(self):
         filename = "G:\\local\\path\\to\\file"
         file = FilePath(filename)
-        self.assertEqual("file:///remote/path/to/file",file.as_remote())
+        self.assertEqual("file:///remote/path//to/file",file.as_remote())
 
         filename = "file:///G:/local2/path/to/file"
         file = FilePath(filename)


### PR DESCRIPTION
If the remote does not end with a / (eg. /remote/path) and the local does (eg.
/local/path/), the_create_remote will break the path, going from:

        /local/path/to/file

to:
        /remote/pathtofile

This commit adds a trailing / to the remote if it does not have any.

It also apply the same process on local in _create_local.

This might solve the issue #263 from @dave2309