### PR TITLE
Fixes #305 - incorrect ui window selection in Neovim

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -117,3 +117,39 @@ git clone https://github.com/joonty/vdebug.git ~/.vim/bundle/vdebug
 cd /vagrant
 bundle install
 EOF
+
+### Neovim installation
+cat <<EOF > /home/vagrant/neovim.sh
+### This script compiles and builds neovim 
+# Install required build tools
+sudo apt-get install pkg-config build-essential libtool automake software-properties-common python-dev -y
+
+# install latest cmake
+# Taken from https://askubuntu.com/questions/355565/how-to-install-latest-cmake-version-in-linux-ubuntu-from-command-line
+#  Uninstall the default version provided by Ubuntu's package manager:
+sudo apt-get purge cmake -y
+# Go to the official CMake webpage, then download and extract the latest version.
+cd /tmp
+wget https://cmake.org/files/v3.9/cmake-3.9.4.tar.gz
+tar -xzvf cmake-3.9.4.tar.gz
+cd cmake-3.9.4/
+# Install the extracted source by running:
+./bootstrap
+make -j4
+sudo make install
+
+# Install the neovim itself
+cd ~ && git clone https://github.com/neovim/neovim.git && cd neovim
+make CMAKE_EXTRA_FLAGS="-DCMAKE_INSTALL_PREFIX=$(echo ~vagrant)/neovim"
+make install
+
+# install neovim-python client
+sudo pip install neovim
+
+# Set ide key
+echo PATH="$(echo ~vagrant)/neovim/build/bin:$PATH" | sudo tee -a /etc/profile
+alias nvim="nvim -u ~/.vimrc"
+EOF
+
+chown vagrant:vagrant /home/vagrant/neovim.sh
+chmod +x /home/vagrant/neovim.sh

--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -46,9 +46,6 @@ class Ui(vdebug.ui.interface.Ui):
 
             self.tabnr = vim.eval("tabpagenr()")
 
-            srcwin_name = self.__get_srcwin_name()
-
-
             self.watchwin = WatchWindow(self,'vertical belowright new')
             self.watchwin.create()
 
@@ -71,8 +68,7 @@ class Ui(vdebug.ui.interface.Ui):
                     vdebug.opts.Options.get('debug_window_level'),\
                     logwin))
 
-            winnr = self.__get_srcwinno_by_name(srcwin_name)
-            self.sourcewin = SourceWindow(self,winnr)
+            self.sourcewin = SourceWindow()
             self.sourcewin.focus()
         except Exception, e:
             self.is_open = False
@@ -190,26 +186,6 @@ class Ui(vdebug.ui.interface.Ui):
         self.statuswin = None
         self.tracewin  = None
 
-
-    def __get_srcwin_name(self):
-        return vim.current.buffer.name
-
-    def __get_srcwinno_by_name(self,name):
-        i = 1
-        vdebug.log.Log("Searching for win by name %s" % name,\
-                vdebug.log.Logger.INFO)
-        for w in vim.windows:
-            vdebug.log.Log("Win %d, name %s" %(i,w.buffer.name),\
-                vdebug.log.Logger.INFO)
-            if w.buffer.name == name:
-                break
-            else:
-                i += 1
-
-        vdebug.log.Log("Returning window number %d" % i,\
-                vdebug.log.Logger.INFO)
-        return i
-
     def __get_buf_list(self):
         return vim.eval("range(1, bufnr('$'))")
 
@@ -219,11 +195,8 @@ class SourceWindow(vdebug.ui.interface.Window):
     pointer_sign_id = '6145'
     breakpoint_sign_id = '6146'
 
-    def __init__(self,ui,winno):
-        self.winno = str(winno)
-
     def focus(self):
-        vim.command(self.winno+"wincmd w")
+        vim.command("1wincmd w")
 
     def command(self,cmd,silent = True):
         self.focus()
@@ -231,7 +204,7 @@ class SourceWindow(vdebug.ui.interface.Window):
             prepend = "silent "
         else:
             prepend = ""
-        command_str = prepend + self.winno + "wincmd " + cmd
+        command_str = prepend + "1wincmd " + cmd
         vim.command(command_str)
 
     def set_file(self,file):


### PR DESCRIPTION
Vim and Neovim seem to manage windows differently.
This patch removes redundant window search for source window
and assumes that the source window is always nr. 1.