### PR TITLE
Allow phar:/// map breakpoint setting

### DIFF
--- a/plugin/python/vdebug/util.py
+++ b/plugin/python/vdebug/util.py
@@ -145,7 +145,9 @@ class FilePath:
                     ret = ret.replace('\\', '/')
                     break
 
-        if ret.startswith('/'):
+        if ret.startswith('phar://'):
+            return ret
+        elif ret.startswith('/'):
             return "file://"+ret
         else:
             return "file:///"+ret


### PR DESCRIPTION
When setting breakpoints, if the resolved remote filename from the path map starts with `phar://` (a local file mapped from a remote phar), don't prepend the filename any further when converting to local filenames so we don't attempt to set breakpoints on paths `file:///phar:///`.