### PR TITLE
Added check to prevent loading plugin twice

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -18,6 +18,17 @@
 "=============================================================================
 " }}}
 
+" Sanity Checks
+
+if exists('g:is_vdebug_loaded')
+    finish
+endif
+
+" Set a special flag used only by this plugin for preventing doubly
+" loading the script.
+let g:is_vdebug_loaded = 1
+
+
 " Do not source this script when python is not compiled in.
 if !has("python")
     finish


### PR DESCRIPTION
Pretty much what the title says. I had an issue with the plugin loading twice in my vimrc. The lines I added just prevent the plugin from loading twice by checking to see if g:is_vdebug_loaded is set or not.