### PR TITLE
Fix crash when function name is multibyte chracter

### DIFF
--- a/plugin/python/vdebug/ui/vimui.py
+++ b/plugin/python/vdebug/ui/vimui.py
@@ -532,7 +532,7 @@ class StackGetResponseRenderer(ResponseRenderer):
         string = ""
         for s in stack:
             if s.get('where'):
-                where = s.get('where')
+                where = s.get('where').encode('latin1')
             else:
                 where = 'main'
             file = vdebug.util.FilePath(s.get('filename'))


### PR DESCRIPTION
Crash vdebug when stacktrace includes multibyte character.
example: `function test_これはテストです() { return true; }`

With stack trace:
```
An error occured: <type 'exceptions.UnicodeEncodeError'>
Traceback (most recent call last):
  File "/home/lamishina/.vim/bundle/vdebug/plugin/python/start_vdebug.py", line 31, in run
    self.runner.run()
  File "/home/lamishina/.vim/bundle/vdebug/plugin/python/vdebug/runner.py", line 189, in run
    self.refresh(res)
  File "/home/lamishina/.vim/bundle/vdebug/plugin/python/vdebug/runner.py", line 120, in refresh
    stack_res = self.update_stack()
  File "/home/lamishina/.vim/bundle/vdebug/plugin/python/vdebug/runner.py", line 346, in update_stack
    self.ui.stackwin.accept_renderer(renderer)
  File "/home/lamishina/.vim/bundle/vdebug/plugin/python/vdebug/ui/vimui.py", line 377, in accept_renderer
    self.write(renderer.render())
  File "/home/lamishina/.vim/bundle/vdebug/plugin/python/vdebug/ui/vimui.py", line 448, in write
    Window.write(self, msg, after="normal gg")
  File "/home/lamishina/.vim/bundle/vdebug/plugin/python/vdebug/ui/vimui.py", line 297, in write
    self.buffer[:] = str(msg).split('
')
UnicodeEncodeError: 'ascii' codec can't encode characters in position 172-192: ordinal not in range(128)
```

This pull request is fix this.
I referenced https://github.com/joonty/vdebug/issues/95.


And I am sorry, I am Japanese.
I cannot speak and write English well.