### PR TITLE
Python3

### DIFF
--- a/plugin/vdebug.vim
+++ b/plugin/vdebug.vim
@@ -3,7 +3,7 @@
 " Script Info  {{{
 "=============================================================================
 "    Copyright: Copyright (C) 2012 Jon Cairns
-"      Licence:	The MIT Licence (see LICENCE file)
+"      Licence: The MIT Licence (see LICENCE file)
 " Name Of File: vdebug.vim
 "  Description: Multi-language debugger client for Vim (PHP, Ruby, Python,
 "               Perl, NodeJS)
@@ -19,14 +19,14 @@
 " }}}
 
 " Do not source this script when python is not compiled in.
-if !has("python")
-    echomsg ":python is not available, vdebug will not be loaded."
+if !has("python3")
+    echomsg ":python3 is not available, vdebug will not be loaded."
     finish
 endif
 
 silent doautocmd User VdebugPre
 
-execute 'pyfile' fnamemodify(expand('<sfile>'), ':p:h:h') . '/pythonx/start_vdebug.py'
+execute 'py3file' fnamemodify(expand('<sfile>'), ':p:h:h') . '/pythonx/start_vdebug.py'
 
 " Nice characters get screwed up on windows
 if has('win32') || has('win64')
@@ -101,16 +101,16 @@ if g:vdebug_force_ascii == 1
 endif
 
 " Create the top dog
-python debugger = vdebug.debugger_interface.DebuggerInterface()
+python3 debugger = vdebug.debugger_interface.DebuggerInterface()
 
 " Commands
-command! -nargs=? -complete=customlist,s:BreakpointTypes Breakpoint python debugger.set_breakpoint(<q-args>)
-command! VdebugStart python debugger.run()
-command! -nargs=? BreakpointRemove python debugger.remove_breakpoint(<q-args>)
-command! BreakpointWindow python debugger.toggle_breakpoint_window()
-command! -nargs=? -bang VdebugEval python debugger.handle_eval('<bang>', <q-args>)
-command! -nargs=+ -complete=customlist,s:OptionNames VdebugOpt python debugger.handle_opt(<f-args>)
-command! -nargs=? VdebugTrace python debugger.handle_trace(<q-args>)
+command! -nargs=? -complete=customlist,s:BreakpointTypes Breakpoint python3 debugger.set_breakpoint(<q-args>)
+command! VdebugStart python3 debugger.run()
+command! -nargs=? BreakpointRemove python3 debugger.remove_breakpoint(<q-args>)
+command! BreakpointWindow python3 debugger.toggle_breakpoint_window()
+command! -nargs=? -bang VdebugEval python3 debugger.handle_eval('<bang>', <q-args>)
+command! -nargs=+ -complete=customlist,s:OptionNames VdebugOpt python3 debugger.handle_opt(<f-args>)
+command! -nargs=? VdebugTrace python3 debugger.handle_trace(<q-args>)
 
 if hlexists("DbgCurrentLine") == 0
     hi default DbgCurrentLine term=reverse ctermfg=White ctermbg=Red guifg=#ffffff guibg=#ff0000
@@ -142,10 +142,10 @@ endfunction
 function! s:HandleEval(bang,code)
     let code = escape(a:code,'"')
     if strlen(a:bang)
-        execute 'python debugger.save_eval("'.code.'")'
+        execute 'python3 debugger.save_eval("'.code.'")'
     endif
     if strlen(a:code)
-        execute 'python debugger.handle_eval("'.code.'")'
+        execute 'python3 debugger.handle_eval("'.code.'")'
     endif
 endfunction
 
@@ -161,7 +161,7 @@ function! Vdebug_load_options(options)
     let single_defined_params = s:Vdebug_get_options()
     let g:vdebug_options = extend(g:vdebug_options, single_defined_params)
 
-    exe ":python debugger.reload_options()"
+    exe ":python3 debugger.reload_options()"
 endfunction
 
 " Get options defined outside of the vdebug_options dictionary
@@ -213,13 +213,13 @@ function! Vdebug_load_keymaps(keymaps)
     let g:vdebug_keymap = extend(g:vdebug_keymap_defaults, a:keymaps)
 
     " Mappings allowed in non-debug mode
-    exe "noremap ".g:vdebug_keymap["run"]." :python debugger.run()<cr>"
-    exe "noremap ".g:vdebug_keymap["close"]." :python debugger.close()<cr>"
-    exe "noremap ".g:vdebug_keymap["set_breakpoint"]." :python debugger.set_breakpoint()<cr>"
+    exe "noremap ".g:vdebug_keymap["run"]." :python3 debugger.run()<cr>"
+    exe "noremap ".g:vdebug_keymap["close"]." :python3 debugger.close()<cr>"
+    exe "noremap ".g:vdebug_keymap["set_breakpoint"]." :python3 debugger.set_breakpoint()<cr>"
 
     " Exceptional case for visual evaluation
-    exe "vnoremap ".g:vdebug_keymap["eval_visual"]." :python debugger.handle_visual_eval()<cr>"
-    exe ":python debugger.reload_keymappings()"
+    exe "vnoremap ".g:vdebug_keymap["eval_visual"]." :python3 debugger.handle_visual_eval()<cr>"
+    exe ":python3 debugger.reload_keymappings()"
 endfunction
 
 function! s:OptionNames(A,L,P)
@@ -259,7 +259,7 @@ function! Vdebug_statusline()
 endfunction
 
 silent doautocmd User VdebugPost
-autocmd VimLeavePre * python debugger.close()
+autocmd VimLeavePre * python3 debugger.close()
 
 call Vdebug_load_options(g:vdebug_options)
 call Vdebug_load_keymaps(g:vdebug_keymap)

--- a/pythonx/vdebug/breakpoint.py
+++ b/pythonx/vdebug/breakpoint.py
@@ -216,7 +216,7 @@ class ConditionalBreakpoint(LineBreakpoint):
 
     def get_cmd(self):
         cmd = LineBreakpoint.get_cmd(self)
-        cmd += " -- " + base64.encodestring(
+        cmd += " -- " + base64.encodebytes(
             self.condition.encode("UTF-8")).decode("UTF-8")
         return cmd
 

--- a/pythonx/vdebug/dbgp.py
+++ b/pythonx/vdebug/dbgp.py
@@ -162,7 +162,11 @@ class EvalResponse(ContextGetResponse):
     def get_code(self):
         cmd = self.get_cmd_args()
         parts = cmd.split('-- ')
-        return base64.decodebytes(parts[1])
+        missing_padding = len(parts[1]) % 4
+        if missing_padding != 0:
+            parts[1] += '='* (4 - missing_padding)
+        #return base64.decodebytes(parts[1])
+        return base64.b64decode(parts[1].encode('ascii'))
 
 
 class BreakpointSetResponse(Response):
@@ -299,7 +303,10 @@ class Api:
         """Tell the debugger to start or resume
         execution."""
         code_enc = base64.encodestring(code.encode("UTF-8"))
-        args = '-- %s' % code_enc
+        #PY3
+        #code_enc = base64.encodestring(code)
+        args = '-- %s' % code_enc.decode('ascii')
+        #print(code_enc.decode('ascii'))
 
         """ The python engine incorrectly requires length.
         if self.language == 'python':

--- a/pythonx/vdebug/listener.py
+++ b/pythonx/vdebug/listener.py
@@ -49,12 +49,12 @@ class BackgroundListener:
 
     def start(self):
         if opts.Options.get("auto_start", int):
-            vim.command('au CursorHold * python debugger.start_if_ready()')
-            vim.command('au CursorHoldI * python debugger.start_if_ready()')
-            vim.command('au CursorMoved * python debugger.start_if_ready()')
-            vim.command('au CursorMovedI * python debugger.start_if_ready()')
-            vim.command('au FocusGained * python debugger.start_if_ready()')
-            vim.command('au FocusLost * python debugger.start_if_ready()')
+            vim.command('au CursorHold * python3 debugger.start_if_ready()')
+            vim.command('au CursorHoldI * python3 debugger.start_if_ready()')
+            vim.command('au CursorMoved * python3 debugger.start_if_ready()')
+            vim.command('au CursorMovedI * python3 debugger.start_if_ready()')
+            vim.command('au FocusGained * python3 debugger.start_if_ready()')
+            vim.command('au FocusLost * python3 debugger.start_if_ready()')
         self.__server.start(opts.Options.get('server'),
                             opts.Options.get('port', int))
 

--- a/pythonx/vdebug/ui/vimui.py
+++ b/pythonx/vdebug/ui/vimui.py
@@ -506,7 +506,7 @@ class Window(interface.Window):
 
         if self.creation_count == 1:
             cmd = 'silent! au BufWinLeave %s' % self.name
-            cmd += ' :python debugger.mark_window_as_closed("%s")' % self.name
+            cmd += ' :python3 debugger.mark_window_as_closed("%s")' % self.name
             vim.command(cmd)
 
         self.on_create()
@@ -583,7 +583,7 @@ class LogWindow(Window):
             cmd = 'silent! au BufWinLeave %s :silent! bdelete %s' % (self.name,
                                                                      self.name)
             vim.command(
-                '%s | python vdebug.log.Log.remove_logger("WindowLogger")'
+                '%s | python3 vdebug.log.Log.remove_logger("WindowLogger")'
                 % cmd)
 
     def write(self, msg, return_focus=True):
@@ -596,11 +596,11 @@ class StackWindow(Window):
 
     def on_create(self):
         self.command('inoremap <buffer> <cr> <esc>'
-                     ':python debugger.handle_return_keypress()<cr>')
+                     ':python3 debugger.handle_return_keypress()<cr>')
         self.command('nnoremap <buffer> <cr> '
-                     ':python debugger.handle_return_keypress()<cr>')
+                     ':python3 debugger.handle_return_keypress()<cr>')
         self.command('nnoremap <buffer> <2-LeftMouse> '
-                     ':python debugger.handle_double_click()<cr>')
+                     ':python3 debugger.handle_double_click()<cr>')
         self.command('setlocal syntax=debugger_stack')
 
     def write(self, msg, return_focus=True):
@@ -617,11 +617,11 @@ class WatchWindow(Window):
 
     def on_create(self):
         self.command('inoremap <buffer> <cr> <esc>'
-                     ':python debugger.handle_return_keypress()<cr>')
+                     ':python3 debugger.handle_return_keypress()<cr>')
         self.command('nnoremap <buffer> <cr> '
-                     ':python debugger.handle_return_keypress()<cr>')
+                     ':python3 debugger.handle_return_keypress()<cr>')
         self.command('nnoremap <buffer> <2-LeftMouse> '
-                     ':python debugger.handle_double_click()<cr>')
+                     ':python3 debugger.handle_double_click()<cr>')
         self.command('setlocal syntax=debugger_watch')
 
     def set_eval_expression(self, eval_expression):
@@ -686,7 +686,7 @@ class TraceWindow(WatchWindow):
             cmd = 'silent! au BufWinLeave %s :silent! bdelete %s' % (self.name,
                                                                      self.name)
             vim.command(
-                '%s | python debugger.runner.ui.tracewin.is_open = False'
+                '%s | python3 debugger.runner.ui.tracewin.is_open = False'
                 % cmd)
         self.command('setlocal syntax=debugger_watch')
 
@@ -791,7 +791,8 @@ class ContextGetResponseRenderer(ResponseRenderer):
             'marker': self.__get_marker(p),
             'name': p.display_name.encode('ascii'),
             'type': p.type_and_size(),
-            'value': " " + p.value.encode('ascii')
+            #'value': " " + p.value.encode('ascii')
+            'value': " " + p.value
         }
         line = line.rstrip() + "\n"
 

--- a/pythonx/vdebug/ui/vimui.py
+++ b/pythonx/vdebug/ui/vimui.py
@@ -789,7 +789,8 @@ class ContextGetResponseRenderer(ResponseRenderer):
         line = "%(indent)s %(marker)s %(name)s = (%(type)s)%(value)s" % {
             'indent': indent_str,
             'marker': self.__get_marker(p),
-            'name': p.display_name.encode('ascii'),
+            #'name': p.display_name.decode('ascii'),
+            'name': p.display_name,
             'type': p.type_and_size(),
             #'value': " " + p.value.encode('ascii')
             'value': " " + p.value

--- a/pythonx/vdebug/util.py
+++ b/pythonx/vdebug/util.py
@@ -130,7 +130,7 @@ class Keymapper:
         for func in self.keymaps:
             if func not in self.exclude:
                 key = self.keymaps[func]
-                map_cmd = "noremap %s%s :python debugger.%s()<cr>" % (
+                map_cmd = "noremap %s%s :python3 debugger.%s()<cr>" % (
                     self.leader, key, func)
                 vim.command(map_cmd)
         self.is_mapped = True

--- a/tests/test_breakpoint_breakpoint.py
+++ b/tests/test_breakpoint_breakpoint.py
@@ -64,7 +64,7 @@ class ConditionalBreakpointTest(unittest.TestCase):
         line = 20
         condition = "$x > 20"
         bp = vdebug.breakpoint.ConditionalBreakpoint(ui,file,line,condition)
-        b64cond = base64.encodestring(condition.encode("UTF-8")).decode("UTF-8")
+        b64cond = base64.encodebytes(condition.encode("UTF-8")).decode("UTF-8")
         exp_cmd = "-t conditional -f \"file://%s\" -n %i -s enabled -- %s" %(file, line, b64cond)
         self.assertEqual(bp.get_cmd(), exp_cmd)
 
@@ -120,7 +120,7 @@ class BreakpointTest(unittest.TestCase):
         Mock.__len__ = Mock(return_value=0)
         ui = Mock()
         re = 'Cannot set a breakpoint on an empty line'
-        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
+        self.assertRaisesRegex(vdebug.error.BreakpointError,\
                 re,vdebug.breakpoint.Breakpoint.parse,ui,"")
 
     def test_parse_with_conditional_breakpoint(self):
@@ -136,7 +136,7 @@ class BreakpointTest(unittest.TestCase):
         args = "conditional"
         re = "Conditional breakpoints require a condition "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
+        self.assertRaisesRegex(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 
     def test_parse_with_exception_breakpoint(self):
@@ -152,7 +152,7 @@ class BreakpointTest(unittest.TestCase):
         args = "exception"
         re = "Exception breakpoints require an exception name "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
+        self.assertRaisesRegex(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 
 
@@ -169,7 +169,7 @@ class BreakpointTest(unittest.TestCase):
         args = "call"
         re = "Call breakpoints require a function name "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
+        self.assertRaisesRegex(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 
     def test_parse_with_return_breakpoint(self):
@@ -185,6 +185,6 @@ class BreakpointTest(unittest.TestCase):
         args = "return"
         re = "Return breakpoints require a function name "+\
                 "to be specified"
-        self.assertRaisesRegexp(vdebug.error.BreakpointError,\
+        self.assertRaisesRegex(vdebug.error.BreakpointError,\
                 re, vdebug.breakpoint.Breakpoint.parse, ui, args)
 

--- a/tests/test_dbgp_api.py
+++ b/tests/test_dbgp_api.py
@@ -177,5 +177,5 @@ class apiInvalidInitTest(unittest.TestCase):
             c.recv_msg.return_value = self.invalid_init_msg
             c.isconnected.return_value = 1
             re = "Invalid XML response from debugger"
-            self.assertRaisesRegexp(vdebug.dbgp.ResponseError,re,vdebug.dbgp.Api,c)
+            self.assertRaisesRegex(vdebug.dbgp.ResponseError,re,vdebug.dbgp.Api,c)
 

--- a/tests/test_dbgp_connection.py
+++ b/tests/test_dbgp_connection.py
@@ -8,7 +8,7 @@ class SocketMockError():
 class SocketMock():
     def __init__(self):
         self.response = []
-        self.last_msg = None
+        self.last_msg = []
 
     def recv(self,length):
         ret = self.response[0]
@@ -19,21 +19,39 @@ class SocketMock():
                 self.response[0] = newval
             else:
                 self.response.pop(0)
-            return "".join(chars)
+            if (length == 1):
+                return b"".join(chars)
+            else :
+                return chars
+            #if type(chars[0]) is int:
+            #    print("len same as length")
+            #    print(ret[0:length])
+            #    return b''.join([bytes(i) for i in chars])
+            #    return b"".join(chars)
+            #else:
+            #    return b"".join(chars)
         else:
             self.response.pop(0)
-            return ''
+            return b''
 
     def add_response(self,res):
-        res = str(res)
-        self.response.append(list(res))
-        self.response.append(['\0'])
+        digitlist = []
+        for i in str(res):
+            digitlist.append(bytes(i, "utf8"))
+        self.response.append(digitlist)
+
+        #res = bytes(res, 'utf8')
+        #self.response.append(list(res))
+        self.response.append([b'\x00'])
 
     def send(self,msg):
-        self.last_msg = msg
+        self.last_msg.append( msg )
+        return len(msg)
 
     def get_last_sent(self):
-        return self.last_msg
+        last = self.last_msg
+        self.last_msg = [];
+        return b''.join(last).decode('UTF-8')
 
     def close(self):
         pass

--- a/tests/test_dbgp_response.py
+++ b/tests/test_dbgp_response.py
@@ -51,7 +51,7 @@ class ResponseTest(unittest.TestCase):
             code="5"><message><![CDATA[command is not available]]>
             </message></error></response>"""
         re = "command is not available"
-        self.assertRaisesRegexp(vdebug.dbgp.DBGPError,re,vdebug.dbgp.Response,response,"","",Mock())
+        self.assertRaisesRegex(vdebug.dbgp.DBGPError,re,vdebug.dbgp.Response,response,"","",Mock())
 
 class StatusResponseTest(unittest.TestCase):
     """Test the behaviour of the StatusResponse class."""


### PR DESCRIPTION
This replaces python2 support with python 3 specific function calls.  Works on Ubuntu 17.10 version of VIM which does not have py2 support.

Mocking the test socket is not done so tests will fail.